### PR TITLE
Issue #56

### DIFF
--- a/platform-web-resources/src/main/java/ua/com/fielden/platform/web/resources/FileResource.java
+++ b/platform-web-resources/src/main/java/ua/com/fielden/platform/web/resources/FileResource.java
@@ -1,12 +1,17 @@
 package ua.com.fielden.platform.web.resources;
 
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
 
 import org.restlet.Context;
 import org.restlet.Request;
 import org.restlet.Response;
+import org.restlet.data.Encoding;
 import org.restlet.data.MediaType;
+import org.restlet.engine.application.EncodeRepresentation;
 import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.resource.ResourceException;
@@ -26,10 +31,22 @@ public class FileResource extends ServerResource {
     @Override
     protected Representation get() throws ResourceException {
         try {
-            return new InputRepresentation(new FileInputStream(fileName), mediaType);
+            return new EncodeRepresentation(Encoding.GZIP, new InputRepresentation(new FileInputStream(fileName), mediaType));
         } catch (final FileNotFoundException e) {
             e.printStackTrace();
             return null;
         }
     }
+    
+//	private static String compress(final String str) throws IOException {
+//		if (str == null || str.length() == 0) {
+//			return str;
+//		}
+//		ByteArrayOutputStream out = new ByteArrayOutputStream();
+//		GZIPOutputStream gzip = new GZIPOutputStream(out);
+//		gzip.write(str.getBytes());
+//		gzip.close();
+//		String outStr = out.toString("UTF-8");
+//		return outStr;
+//	}
 }


### PR DESCRIPTION
GZIB-compressed resources, which are sending from the server to the web-browser client, are fully supported and correctly recognised by all modern browsers (including JavaFX WebView browser). Very simple wrapping has been introduced for all file-system resources, which are registered with the server.

The way "web-browser client => server" should be supported explicitly:
- at the browser-client side (enhance envelope with appropriate GZIP header + encode content);
- at the server side (enhance GZIPped envelope recognition -- provide automatic behaviour).
  This way will be covered by a separate issue at the later stages.

Please review & comment.
