### PR TITLE
Made EntityCentreConfig 'self-conflict resolvable', aka all savings w…

### DIFF
--- a/platform-dao/src/main/java/ua/com/fielden/platform/companion/PersistentEntitySaver.java
+++ b/platform-dao/src/main/java/ua/com/fielden/platform/companion/PersistentEntitySaver.java
@@ -72,7 +72,7 @@ import ua.com.fielden.platform.utils.EntityUtils;
  * @param <T>
  */
 public final class PersistentEntitySaver<T extends AbstractEntity<?>> implements IEntityActuator<T> {
-
+    public static final String ERR_COULD_NOT_RESOLVE_CONFLICTING_CHANGES = "Could not resolve conflicting changes.";
     private final Supplier<Session> session;
     private final Supplier<String> transactionGuid;
     private final Supplier<DbVersion> dbVersion;
@@ -236,7 +236,7 @@ public final class PersistentEntitySaver<T extends AbstractEntity<?>> implements
         persistedEntity.setIgnoreEditableState(true);
         // check for data staleness and try to resolve the conflict is possible (refer #83)
         if (persistedEntity.getVersion() != null && persistedEntity.getVersion() > entity.getVersion() && !canResolveConflict(entity, persistedEntity)) {
-            throw new EntityCompanionException(format("Could not resolve conflicting changes. %s [%s] could not be saved.", TitlesDescsGetter.getEntityTitleAndDesc(entityType).getKey(), entity));
+            throw new EntityCompanionException(format("%s %s [%s] could not be saved.", ERR_COULD_NOT_RESOLVE_CONFLICTING_CHANGES, TitlesDescsGetter.getEntityTitleAndDesc(entityType).getKey(), entity));
         }
 
         // reconstruct entity fetch model for future retrieval at the end of the method call

--- a/platform-dao/src/main/java/ua/com/fielden/platform/ui/config/controller/EntityCentreConfigDao.java
+++ b/platform-dao/src/main/java/ua/com/fielden/platform/ui/config/controller/EntityCentreConfigDao.java
@@ -1,12 +1,17 @@
 package ua.com.fielden.platform.ui.config.controller;
 
+import static ua.com.fielden.platform.companion.PersistentEntitySaver.ERR_COULD_NOT_RESOLVE_CONFLICTING_CHANGES;
+import static ua.com.fielden.platform.utils.EntityUtils.isConflicting;
+
 import java.util.Map;
 
 import com.google.inject.Inject;
 
 import ua.com.fielden.platform.dao.CommonEntityDao;
 import ua.com.fielden.platform.dao.annotations.SessionRequired;
+import ua.com.fielden.platform.dao.exceptions.EntityCompanionException;
 import ua.com.fielden.platform.entity.annotation.EntityType;
+import ua.com.fielden.platform.entity.meta.MetaProperty;
 import ua.com.fielden.platform.entity.query.IFilter;
 import ua.com.fielden.platform.entity.query.model.EntityResultQueryModel;
 import ua.com.fielden.platform.ui.config.EntityCentreConfig;
@@ -20,18 +25,18 @@ import ua.com.fielden.platform.ui.config.api.IEntityCentreConfig;
  */
 @EntityType(EntityCentreConfig.class)
 public class EntityCentreConfigDao extends CommonEntityDao<EntityCentreConfig> implements IEntityCentreConfig {
-
+    
     @Inject
     protected EntityCentreConfigDao(final IFilter filter) {
         super(filter);
     }
-
+    
     @Override
     @SessionRequired
     public void delete(final EntityCentreConfig entity) {
         defaultDelete(entity);
     }
-
+    
     @Override
     @SessionRequired
     public void delete(final EntityResultQueryModel<EntityCentreConfig> model, final Map<String, Object> paramValues) {
@@ -40,7 +45,30 @@ public class EntityCentreConfigDao extends CommonEntityDao<EntityCentreConfig> i
     
     @Override
     @SessionRequired
-    public int batchDelete(EntityResultQueryModel<EntityCentreConfig> model) {
+    public int batchDelete(final EntityResultQueryModel<EntityCentreConfig> model) {
         return defaultBatchDelete(model);
     }
+    
+    @Override
+    @SessionRequired
+    public EntityCentreConfig save(final EntityCentreConfig entity) {
+        try {
+            return super.save(entity);
+        } catch (final EntityCompanionException companionException) {
+            if (companionException.getMessage() != null && companionException.getMessage().contains(ERR_COULD_NOT_RESOLVE_CONFLICTING_CHANGES)) { // conflict could occur for concrete user, miType and surrogate+saveAs name
+                // Need to repeat saving of entity in case of "self conflict": in a concurrent environment the same user on the same entity centre configuration can trigger multiple concurrent validations with different parameters.
+                final EntityCentreConfig persistedEntity = findByEntityAndFetch(null, entity);
+                for (final MetaProperty<?> prop : entity.getDirtyProperties()) { // the only two properties that can be conflicting: 'configBody' (most cases) and 'desc' (rare, but possible); other properties are the parts of key and will not conflict
+                    final String name = prop.getName();
+                    if (isConflicting(prop.getValue(), prop.getOriginalValue(), persistedEntity.get(name))) {
+                        persistedEntity.set(name, prop.getValue());
+                    }
+                }
+                return save(persistedEntity); // repeat the procedure of 'conflict-aware' saving in cases of subsequent conflicts
+            } else {
+                throw companionException;
+            }
+        }
+    }
+    
 }

--- a/platform-dao/src/test/java/ua/com/fielden/platform/entity/AutomaticConflictResolutionTest.java
+++ b/platform-dao/src/test/java/ua/com/fielden/platform/entity/AutomaticConflictResolutionTest.java
@@ -1,7 +1,9 @@
 package ua.com.fielden.platform.entity;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static ua.com.fielden.platform.companion.PersistentEntitySaver.ERR_COULD_NOT_RESOLVE_CONFLICTING_CHANGES;
 import static ua.com.fielden.platform.entity.query.fluent.EntityQueryUtils.fetchAll;
 
 import org.junit.Test;
@@ -47,7 +49,7 @@ public class AutomaticConflictResolutionTest extends AbstractDaoTestCase {
             save(cat1_v2.setDesc("other desc"));
             fail("Saving should have failed");
         } catch (final EntityCompanionException ex) {
-            assertEquals("Could not resolve conflicting changes. Tg Category [Cat1] could not be saved.", ex.getMessage());
+            assertEquals(format("%s Tg Category [Cat1] could not be saved.", ERR_COULD_NOT_RESOLVE_CONFLICTING_CHANGES), ex.getMessage());
         }
 
     }

--- a/platform-dao/src/test/java/ua/com/fielden/platform/ui/entity/centre/EntityCentreConfigPersistenceTest.java
+++ b/platform-dao/src/test/java/ua/com/fielden/platform/ui/entity/centre/EntityCentreConfigPersistenceTest.java
@@ -1,8 +1,6 @@
 package ua.com.fielden.platform.ui.entity.centre;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,37 +28,160 @@ public class EntityCentreConfigPersistenceTest extends AbstractDaoTestCase {
     private final IEntityCentreConfig dao = getInstance(EntityCentreConfigDao.class);
     private final IMainMenuItem menuDao = getInstance(MainMenuItemDao.class);
     private final IUser userDao = getInstance(UserDao.class);
-
+    
     @Test
     public void test_insertion_and_retrieval_of_binary_data() {
         final EntityCentreConfig config = new_composite(EntityCentreConfig.class, userDao.findByKey("USER"), "CONFIG 1", menuDao.findByKey("type"));
         config.setDesc("desc");
         config.setConfigBody(new byte[] { 1, 2, 3 });
         dao.save(config);
-
+        
         final List<EntityCentreConfig> result = dao.getPage(0, 25).data();
         assertEquals("Incorrect number of retrieved configurations.", 1, result.size());
         assertTrue("Incorrectly saved binary property.", Arrays.equals(new byte[] { 1, 2, 3 }, result.get(0).getConfigBody()));
     }
-
+    
     @Test
     public void test_update_of_binary_data() {
         EntityCentreConfig config = new_composite(EntityCentreConfig.class, userDao.findByKey("USER"), "CONFIG 1", menuDao.findByKey("type"));
         config.setConfigBody(new byte[] { 1, 2, 3 });
         config.setDesc("desc");
         dao.save(config);
-
+        
         assertEquals("Incorrect version.", Long.valueOf("0"), config.getVersion());
         config.setConfigBody(new byte[] { 1, 2, 3, 4 });
         config = dao.save(config);
         assertEquals("Incorrect version.", Long.valueOf("1"), config.getVersion());
-
+        
         final EntityCentreConfig fromDb = dao.findById(config.getId());
-
+        
         assertNotNull("Configuration entity should exist.", fromDb);
         assertTrue("Incorrectly updated binary property.", Arrays.equals(new byte[] { 1, 2, 3, 4 }, fromDb.getConfigBody()));
     }
-
+    
+    // ========================================== CONFLICTING CHANGES RESOLUTION ==========================================
+    // The following tests are based on the situation of the same 1) user 2) config name 3) menu item. Other conflicts will not be automatically resolved due to composite-key nature of 'owner', 'title' and 'menuItem' properties
+    @Test
+    public void conflicting_changes_in_EntityCentreConfig_configBody_override_without_exceptions() {
+        final EntityCentreConfig config = new_composite(EntityCentreConfig.class, userDao.findByKey("USER"), "CONFIG 1", menuDao.findByKey("type"));
+        config.setConfigBody(new byte[] { 0 });
+        config.setDesc("desc0");
+        dao.save(config);
+        assertEquals("Incorrect version.", Long.valueOf("0"), config.getVersion());
+        
+        // |----------------| first
+        //       |-------------------------| second
+        
+        final EntityCentreConfig firstlyRetrieved = dao.findByEntityAndFetch(null, config);
+        firstlyRetrieved.setConfigBody(new byte[] { 1 });
+        
+        final EntityCentreConfig secondlyRetrieved = dao.findByEntityAndFetch(null, config);
+        secondlyRetrieved.setConfigBody(new byte[] { 2 });
+        
+        // save firstlyRetrieved
+        final EntityCentreConfig firstlyRetrievedAndSaved = dao.save(firstlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("1"), firstlyRetrievedAndSaved.getVersion());
+        assertTrue("Incorrect value.", Arrays.equals(new byte[] { 1 }, firstlyRetrievedAndSaved.getConfigBody()));
+        
+        // after that save secondlyRetrieved and it should not give any conflicting error but instead should complete saving successfully
+        final EntityCentreConfig secondlyRetrievedAndSaved = dao.save(secondlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("2"), secondlyRetrievedAndSaved.getVersion());
+        assertTrue("Incorrect value.", Arrays.equals(new byte[] { 2 }, secondlyRetrievedAndSaved.getConfigBody()));
+    }
+    
+    @Test
+    public void conflicting_changes_in_EntityCentreConfig_desc_override_without_exceptions() {
+        final EntityCentreConfig config = new_composite(EntityCentreConfig.class, userDao.findByKey("USER"), "CONFIG 1", menuDao.findByKey("type"));
+        config.setConfigBody(new byte[] { 0 });
+        config.setDesc("desc0");
+        dao.save(config);
+        assertEquals("Incorrect version.", Long.valueOf("0"), config.getVersion());
+        
+        // |----------------| first
+        //       |-------------------------| second
+        
+        final EntityCentreConfig firstlyRetrieved = dao.findByEntityAndFetch(null, config);
+        firstlyRetrieved.setDesc("desc1");
+        
+        final EntityCentreConfig secondlyRetrieved = dao.findByEntityAndFetch(null, config);
+        secondlyRetrieved.setDesc("desc2");
+        
+        // save firstlyRetrieved
+        final EntityCentreConfig firstlyRetrievedAndSaved = dao.save(firstlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("1"), firstlyRetrievedAndSaved.getVersion());
+        assertEquals("Incorrect value.", "desc1", firstlyRetrievedAndSaved.getDesc());
+        
+        // after that save secondlyRetrieved and it should not give any conflicting error but instead should complete saving successfully
+        final EntityCentreConfig secondlyRetrievedAndSaved = dao.save(secondlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("2"), secondlyRetrievedAndSaved.getVersion());
+        assertEquals("Incorrect value.", "desc2", secondlyRetrievedAndSaved.getDesc());
+    }
+    
+    @Test
+    public void conflicting_changes_in_EntityCentreConfig_desc_override_without_exceptions_when_saving_order_switched() {
+        final EntityCentreConfig config = new_composite(EntityCentreConfig.class, userDao.findByKey("USER"), "CONFIG 1", menuDao.findByKey("type"));
+        config.setConfigBody(new byte[] { 0 });
+        config.setDesc("desc0");
+        dao.save(config);
+        assertEquals("Incorrect version.", Long.valueOf("0"), config.getVersion());
+        
+        // |----------------------------| first
+        //       |----------------| second
+        
+        final EntityCentreConfig firstlyRetrieved = dao.findByEntityAndFetch(null, config);
+        firstlyRetrieved.setDesc("desc1");
+        
+        final EntityCentreConfig secondlyRetrieved = dao.findByEntityAndFetch(null, config);
+        secondlyRetrieved.setDesc("desc2");
+        
+        // save secondlyRetrieved
+        final EntityCentreConfig secondlyRetrievedAndSaved = dao.save(secondlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("1"), secondlyRetrievedAndSaved.getVersion());
+        assertEquals("Incorrect value.", "desc2", secondlyRetrievedAndSaved.getDesc());
+        
+        // after that, save firstlyRetrieved and it should not give any conflicting error but instead should complete saving successfully
+        final EntityCentreConfig firstlyRetrievedAndSaved = dao.save(firstlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("2"), firstlyRetrievedAndSaved.getVersion());
+        assertEquals("Incorrect value.", "desc1", firstlyRetrievedAndSaved.getDesc());
+    }
+    
+    @Test
+    public void multiple_conflicting_changes_in_EntityCentreConfig_configBody_override_without_exceptions() {
+        final EntityCentreConfig config = new_composite(EntityCentreConfig.class, userDao.findByKey("USER"), "CONFIG 1", menuDao.findByKey("type"));
+        config.setConfigBody(new byte[] { 0 });
+        config.setDesc("desc0");
+        dao.save(config);
+        assertEquals("Incorrect version.", Long.valueOf("0"), config.getVersion());
+        
+        // |----------------| first
+        //       |-------------------------| second
+        //                      |-----| third
+        
+        final EntityCentreConfig firstlyRetrieved = dao.findByEntityAndFetch(null, config);
+        firstlyRetrieved.setConfigBody(new byte[] { 1 });
+        
+        final EntityCentreConfig secondlyRetrieved = dao.findByEntityAndFetch(null, config);
+        secondlyRetrieved.setConfigBody(new byte[] { 2 });
+        
+        // save firstlyRetrieved
+        final EntityCentreConfig firstlyRetrievedAndSaved = dao.save(firstlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("1"), firstlyRetrievedAndSaved.getVersion());
+        assertTrue("Incorrect value.", Arrays.equals(new byte[] { 1 }, firstlyRetrievedAndSaved.getConfigBody()));
+        
+        final EntityCentreConfig thirdlyRetrieved = dao.findByEntityAndFetch(null, config);
+        thirdlyRetrieved.setConfigBody(new byte[] { 3 });
+        // save thirdlyRetrieved
+        final EntityCentreConfig thirdlyRetrievedAndSaved = dao.save(thirdlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("2"), thirdlyRetrievedAndSaved.getVersion());
+        assertTrue("Incorrect value.", Arrays.equals(new byte[] { 3 }, thirdlyRetrievedAndSaved.getConfigBody()));
+        
+        // after that, save secondlyRetrieved and it should not give any conflicting error but instead should complete saving successfully
+        final EntityCentreConfig secondlyRetrievedAndSaved = dao.save(secondlyRetrieved);
+        assertEquals("Incorrect version.", Long.valueOf("3"), secondlyRetrievedAndSaved.getVersion());
+        assertTrue("Incorrect value.", Arrays.equals(new byte[] { 2 }, secondlyRetrievedAndSaved.getConfigBody()));
+    }
+    // ========================================== CONFLICTING CHANGES RESOLUTION [END] ==========================================
+    
     @Override
     protected void populateDomain() {
         super.populateDomain();
@@ -68,5 +189,5 @@ public class EntityCentreConfigPersistenceTest extends AbstractDaoTestCase {
         save(new_(User.class, "USER", "DESC").setBase(true).setEmail("USER@unit-test.software").setActive(true));
         save(new_(MainMenuItem.class, "type", "desc").setOrder(1));
     }
-
+    
 }

--- a/platform-web-ui/src/main/java/ua/com/fielden/platform/web/centre/CentreUpdater.java
+++ b/platform-web-ui/src/main/java/ua/com/fielden/platform/web/centre/CentreUpdater.java
@@ -223,10 +223,10 @@ public class CentreUpdater {
         }
         
         // save
-        eccCompanion.quickSave(freshConfig);
-        eccCompanion.quickSave(savedConfig);
+        eccCompanion.save(freshConfig);
+        eccCompanion.save(savedConfig);
         if (previouslyRunConfig != null) { // previouslyRun centre may not exist
-            eccCompanion.quickSave(previouslyRunConfig);
+            eccCompanion.save(previouslyRunConfig);
         }
     }
     
@@ -386,10 +386,10 @@ public class CentreUpdater {
     public static void makePreferred(final User user, final Class<? extends MiWithConfigurationSupport<?>> miType, final Optional<String> saveAsName, final DeviceProfile device, final ICompanionObjectFinder companionFinder) {
         final IEntityCentreConfig eccCompanion = companionFinder.find(EntityCentreConfig.class);
         try (final Stream<EntityCentreConfig> stream = streamPreferredConfigs(user, miType, device, companionFinder) ) {
-            stream.forEach(ecc -> eccCompanion.quickSave(ecc.setPreferred(false)));
+            stream.forEach(ecc -> eccCompanion.save(ecc.setPreferred(false)));
         }
         if (saveAsName.isPresent()) {
-            eccCompanion.quickSave(
+            eccCompanion.save(
                 findConfig(miType, user, deviceSpecific(saveAsSpecific(FRESH_CENTRE_NAME, saveAsName), device) + DIFFERENCES_SUFFIX, eccCompanion)
                 .setPreferred(true)
             );

--- a/platform-web-ui/src/main/java/ua/com/fielden/platform/web/centre/CentreUpdaterUtils.java
+++ b/platform-web-ui/src/main/java/ua/com/fielden/platform/web/centre/CentreUpdaterUtils.java
@@ -134,7 +134,7 @@ public class CentreUpdaterUtils extends CentreUpdater {
             final ICentreDomainTreeManagerAndEnhancer newCentreManager = createDefaultCentre(menuItemType, webUiConfig);
             logger.error(format("Started saving of default entity-centre configuration %s.", loggingSuffix));
             ecc.setConfigBody(serialiser.serialise(newCentreManager));
-            eccCompanion.quickSave(ecc);
+            eccCompanion.save(ecc);
             logger.error(format("Ended creation and saving of default entity-centre configuration %s. For now it can be used.", loggingSuffix));
             logger.error("============================================ CENTRE DESERIALISATION HAS FAILED [END] ============================================");
             return newCentreManager;
@@ -164,7 +164,7 @@ public class CentreUpdaterUtils extends CentreUpdater {
         ecc.setMenuItem(menuItem);
         ecc.setDesc(newDesc);
         ecc.setConfigBody(serialiser.serialise(centre));
-        eccCompanion.quickSave(ecc);
+        eccCompanion.save(ecc);
         return centre;
     }
     
@@ -189,7 +189,7 @@ public class CentreUpdaterUtils extends CentreUpdater {
                 config.setDesc(newDesc);
             }
             config.setConfigBody(serialiser.serialise(centre));
-            eccCompanion.quickSave(config);
+            eccCompanion.save(config);
         }
         return centre;
     }


### PR DESCRIPTION
…ill succeed in happens-last manner (+tests). This fixes intermittent centre validation issues, where all validation requests promotes new criteria values to the database, even when these requests happen simultaneously (quick checkbox clicking; text typing + immediate checbox clicking).