### PR TITLE
Issue #1521 tooltip fix

### DIFF
--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-entity-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-entity-editor.js
@@ -977,8 +977,8 @@ export class TgEntityEditor extends TgEditor {
 
     _generateTooltip (value, actionAvailable) {
         let tooltip = this._formatTooltipText(value);
-        tooltip += this.propDesc && (tooltip ? '<br><br>' : '') + this.propDesc;
-        tooltip += actionAvailable && ((tooltip ? '<br><br>' : '') + this._getActionTooltip(this.entityMaster));
+        tooltip += this.propDesc ? (tooltip ? '<br><br>' : '') + this.propDesc : '';
+        tooltip += actionAvailable ? ((tooltip ? '<br><br>' : '') + this._getActionTooltip(this.entityMaster)) : '';
         return tooltip;
     }
 


### PR DESCRIPTION
resolve #1521

Fixed tooltip in cases where autocompleter does not have its title action (e.g. single / multi autocompleters in selection criteria, or autocompleters for entity types without master, or autocompleters in error). Avoided problems in case if propDesc gets some empty value like null or undefined.