### PR TITLE
Issue #1931 - String key integrity constraint

### DIFF
--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/domaintree/impl/CalculatedProperty.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/domaintree/impl/CalculatedProperty.java
@@ -36,12 +36,15 @@ import ua.com.fielden.platform.entity.annotation.KeyType;
 import ua.com.fielden.platform.entity.annotation.Observable;
 import ua.com.fielden.platform.entity.annotation.Optional;
 import ua.com.fielden.platform.entity.annotation.Readonly;
+import ua.com.fielden.platform.entity.annotation.SkipDefaultStringKeyMemberValidation;
 import ua.com.fielden.platform.entity.annotation.Title;
 import ua.com.fielden.platform.entity.annotation.mutator.AfterChange;
 import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
 import ua.com.fielden.platform.entity.annotation.mutator.Handler;
 import ua.com.fielden.platform.entity.factory.EntityFactory;
 import ua.com.fielden.platform.entity.query.model.ExpressionModel;
+import ua.com.fielden.platform.entity.validation.RestrictCommasValidator;
+import ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator;
 import ua.com.fielden.platform.error.Result;
 import ua.com.fielden.platform.expression.ExpressionText2ModelConverter;
 import ua.com.fielden.platform.expression.ast.AstNode;
@@ -91,6 +94,7 @@ public/* final */class CalculatedProperty extends AbstractEntity<DynamicEntityKe
     // revalidates "originationProperty" to ensure that it is correct after "contextualExpression" has been changed
     @BeforeChange(@Handler(BceContextualExpressionValidation.class))
     @AfterChange(AceCalculatedPropertyMetaInformationPopulation.class)
+    @SkipDefaultStringKeyMemberValidation(RestrictCommasValidator.class)
     private String contextualExpression;
 
     @IsProperty
@@ -98,6 +102,7 @@ public/* final */class CalculatedProperty extends AbstractEntity<DynamicEntityKe
     @Title(value = "Title", desc = "Calculated property title")
     @BeforeChange(@Handler(BceTitleValidation.class))
     @AfterChange(AceCalculatedPropertyNamePopulation.class)
+    @SkipDefaultStringKeyMemberValidation({RestrictExtraWhitespaceValidator.class, RestrictCommasValidator.class})
     private String title;
 
     // Required contextually and mutable stuff

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/AbstractEntity.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/AbstractEntity.java
@@ -274,18 +274,18 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
     @MapTo("_ID")
     @Title(value = "Id", desc = "Surrogate unique identifier.")
     private Long id;
-    
+
     @MapTo(value = "_VERSION", defaultValue = "0")
     private Long version = 0L;
-    
+
     @IsProperty
     @UpperCase
     @MapTo("KEY_")
     @Required
     private K key;
-    
+
     private final boolean compositeKey;
-    
+
     @IsProperty
     @MapTo("DESC_")
     private String desc;
@@ -297,7 +297,7 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
     public static final String GETKEY = "getKey()";
     public static final String DESC = "desc";
     public static final String KEY_NOT_ASSIGNED = "[key is not assigned]";
-    
+
     /**
      * A flag that provides a way to enforce more strict model verification, which is the default approach.
      */
@@ -704,8 +704,8 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
     }
 
     /**
-     * Early runtime validation of property definitions. This kind of validations should be moved to complile time in due course. 
-     * 
+     * Early runtime validation of property definitions. This kind of validations should be moved to complile time in due course.
+     *
      * @param propName
      * @param type
      * @param isCollectional
@@ -714,19 +714,19 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
      */
     private void earlyRuntimePropertyDefinitionValidation(final String propName, final Class<?> type, final boolean isCollectional, final IsProperty isPropertyAnnotation, final Class<?> propertyAnnotationType) {
         final boolean isNumeric = isNumeric(type);
-        
+
         if (!isNumeric &&
-            (isPropertyAnnotation.precision() != DEFAULT_PRECISION || 
-             isPropertyAnnotation.scale() != DEFAULT_SCALE || 
+            (isPropertyAnnotation.precision() != DEFAULT_PRECISION ||
+             isPropertyAnnotation.scale() != DEFAULT_SCALE ||
              isPropertyAnnotation.trailingZeros() != DEFAULT_TRAILING_ZEROS)) {
             final String error = format(INVALID_USE_OF_NUMERIC_PARAMS_MSG,  propName, getType().getName());
             logger.error(error);
             throw new EntityDefinitionException(error);
-            
+
         }
 
         if (isNumeric &&
-            (isPropertyAnnotation.precision() != DEFAULT_PRECISION || isPropertyAnnotation.scale() != DEFAULT_SCALE) && 
+            (isPropertyAnnotation.precision() != DEFAULT_PRECISION || isPropertyAnnotation.scale() != DEFAULT_SCALE) &&
             (isPropertyAnnotation.precision() <= 0 || isPropertyAnnotation.scale() < 0)) {
             final String error = format(INVALID_USE_FOR_PRECITION_AND_SCALE_MSG, propName, getType().getName());
             logger.error(error);
@@ -737,7 +737,7 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
                 final String error = format(INVALID_VALUES_FOR_PRECITION_AND_SCALE_MSG, propName, getType().getName());
                 logger.error(error);
                 throw new EntityDefinitionException(error);
-                
+
         }
 
         if (!isString(type) && !type.isArray() && isPropertyAnnotation.length() != DEFAULT_LENGTH) {
@@ -745,7 +745,7 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
             logger.error(error);
             throw new EntityDefinitionException(error);
         }
-        
+
         if ((isCollectional || PropertyDescriptor.class.isAssignableFrom(type)) && (propertyAnnotationType == Void.class || propertyAnnotationType == null)) {
             final String error = format(COLLECTIONAL_PROP_MISSING_TYPE_MSG, propName, getType().getName());
             logger.error(error);
@@ -1367,7 +1367,7 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
             assertEntityFactoryPresence();
             copy = getEntityFactory().newEntity(type, getId());
         } else {
-            copy = EntityFactory.newPlainEntity(type,  getId()); 
+            copy = EntityFactory.newPlainEntity(type,  getId());
         }
         copy.setVersion(getVersion());
         return copy;

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/AbstractEntity.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/AbstractEntity.java
@@ -805,10 +805,11 @@ public abstract class AbstractEntity<K extends Comparable> implements Comparable
             // The returned Set is mutable
             final Set<Annotation> propValidationAnnots = extractValidationAnnotationForProperty(field, propertyType, isCollectional);
 
-            // let's add implicit validation as early as possible to @BeforeChange
-            // special validation of String-typed key-members
-            // applied on top of existing @BeforeChange validators, but ordered before declared handlers
-            if (Finder.isKey(field) && String.class == field.getType()) {
+            // let's add implicit default validation as early as possible to @BeforeChange
+            // special validation of String-typed key or String-typed key-members
+            // applied on top of existing @BeforeChange validators, if any, but placed before the explicitly defined handlers
+            if (AbstractEntity.KEY.equals(field.getName()) && String.class == this.getKeyType() || // the type of property "key" cannot be determined from field, hence a separate check
+                field.isAnnotationPresent(CompositeKeyMember.class) && String.class == field.getType()) {
                 final SkipDefaultStringKeyMemberValidation skipAnnot = field.getAnnotation(SkipDefaultStringKeyMemberValidation.class);
                 final Set<Class<? extends IBeforeChangeEventHandler<String>>> allDefaultStringValidators = linkedSetOf(SkipDefaultStringKeyMemberValidation.ALL_DEFAULT_STRING_KEY_VALIDATORS);
                 allDefaultStringValidators.removeAll(skipAnnot == null ? emptySet() : setOf(skipAnnot.value()));

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/SkipDefaultStringKeyMemberValidation.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/SkipDefaultStringKeyMemberValidation.java
@@ -1,0 +1,37 @@
+package ua.com.fielden.platform.entity.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import ua.com.fielden.platform.entity.validation.IBeforeChangeEventHandler;
+import ua.com.fielden.platform.entity.validation.RestrictCommasValidator;
+import ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator;
+import ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator;
+
+/**
+ * This annotation is applicable to entity key members of type {@code String}, which should have the default string constraints relaxed.
+ * Attribute {@code value} can be assigned when annotating a key-member field to skip specific validators. Otherwise, all default string validators would be skipped.
+ * <p>
+ * For example, the following snippet declares a composite key member {@code title} with validators {@code RestrictExtraWhitespaceValidator} and {@code RestrictCommasValidator} skipped.
+ * <pre>
+ *   &#64;IsProperty
+ *   &#64;CompositeKeyMember(1)
+ *   &#64;Title(value = "Title", desc = "Calculated property title")
+ *   &#64;SkipDefaultStringValidation({RestrictExtraWhitespaceValidator.class, RestrictCommasValidator.class})
+ *   private String title;
+ * </pre>
+ *
+ * @author TG Team
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface SkipDefaultStringKeyMemberValidation {
+
+    static final Class<? extends IBeforeChangeEventHandler<String>>[] ALL_DEFAULT_STRING_KEY_VALIDATORS = new Class[]{RestrictNonPrintableCharactersValidator.class, RestrictExtraWhitespaceValidator.class, RestrictCommasValidator.class};
+    
+    Class<? extends IBeforeChangeEventHandler<String>>[] value() default {RestrictNonPrintableCharactersValidator.class, RestrictExtraWhitespaceValidator.class, RestrictCommasValidator.class};
+
+}

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
@@ -1,9 +1,11 @@
 package ua.com.fielden.platform.entity.annotation.factory;
 
-import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
 import ua.com.fielden.platform.entity.annotation.mutator.Handler;
+import ua.com.fielden.platform.entity.exceptions.InvalidArgumentException;
 
 /**
  * A factory for convenient instantiation of {@link BeforeChange} annotations, which mainly should be used for dynamic property creation.
@@ -19,25 +21,46 @@ public class BeforeChangeAnnotation {
         this.value = value;
     }
 
-    public static BeforeChange from(final Handler... handlers) {
+    /**
+     * A factory method instantiating {@link BeforeChange} with {@code handlers}.
+     *
+     * @param handlers
+     * @return
+     */
+    public static BeforeChange newInstance(final Handler... handlers) {
         return new BeforeChangeAnnotation(handlers).newInstance();
     }
 
     /**
-     * Returns the result of merging {@link BeforeChange} annotation instances.
-     * Handlers of the resulting annotation are ordered in the same way as given annotations. No deduplication takes place.
-     * <p>
-     * If a single annotation is given, then it is simply returned back.
+     * Returns an instance of {@link BeforeChange} with {@code value} containing all handlers from {@code annotations}.
+     * Handlers of the resulting annotation are ordered in the same way as in {@code annotations}, but no deduplication of handlers takes place.
      *
      * @param annotations {@link BeforeChange} instances to be merged
      * @return merged instance of the {@link BeforeChange} annotation
      */
-    public static BeforeChange merged(final BeforeChange... annotations) {
-        if (annotations.length == 1) return annotations[0];
-        final Handler[] handlers = Arrays.stream(annotations).flatMap(bch -> Arrays.stream(bch.value())).toArray(Handler[]::new);
-        return new BeforeChangeAnnotation(handlers).newInstance();
+    public static BeforeChange merge(final BeforeChange... annotations) {
+        if (annotations == null || annotations.length == 0) {
+            throw new InvalidArgumentException("There are no BeforeChange annotations to merge.");
+        }
+        if (Stream.of(annotations).anyMatch(Objects::isNull)) {
+            throw new InvalidArgumentException("No annotation can be null.");
+        }
+        if (annotations == null || annotations.length == 0) {
+            throw new InvalidArgumentException("There are no BeforeChange annotations to merge.");
+        }
+
+        if (annotations.length == 1) {
+            return annotations[0];
+        }
+        final Handler[] mergedHandlers = Stream.of(annotations).flatMap(bch -> Stream.of(bch.value())).toArray(Handler[]::new);
+        return new BeforeChangeAnnotation(mergedHandlers).newInstance();
     }
 
+    /**
+     * Creates a new instance of {@link BeforeChange}.
+     *
+     * @return
+     */
     public BeforeChange newInstance() {
         return new BeforeChange() {
 
@@ -49,21 +72,6 @@ public class BeforeChangeAnnotation {
             @Override
             public Handler[] value() {
                 return value;
-            }
-        };
-    }
-
-    public BeforeChange copyFrom(final BeforeChange bch) {
-        return new BeforeChange() {
-
-            @Override
-            public Class<BeforeChange> annotationType() {
-                return BeforeChange.class;
-            }
-
-            @Override
-            public Handler[] value() {
-                return bch.value();
             }
         };
     }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
@@ -45,9 +45,6 @@ public class BeforeChangeAnnotation {
         if (Stream.of(annotations).anyMatch(Objects::isNull)) {
             throw new InvalidArgumentException("No annotation can be null.");
         }
-        if (annotations == null || annotations.length == 0) {
-            throw new InvalidArgumentException("There are no BeforeChange annotations to merge.");
-        }
 
         if (annotations.length == 1) {
             return annotations[0];

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
@@ -1,13 +1,15 @@
 package ua.com.fielden.platform.entity.annotation.factory;
 
+import java.util.Arrays;
+
 import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
 import ua.com.fielden.platform.entity.annotation.mutator.Handler;
 
 /**
  * A factory for convenient instantiation of {@link BeforeChange} annotations, which mainly should be used for dynamic property creation.
- * 
+ *
  * @author TG Team
- * 
+ *
  */
 public class BeforeChangeAnnotation {
 
@@ -18,6 +20,21 @@ public class BeforeChangeAnnotation {
     }
 
     public static BeforeChange from(final Handler... handlers) {
+        return new BeforeChangeAnnotation(handlers).newInstance();
+    }
+
+    /**
+     * Returns the result of merging {@link BeforeChange} annotation instances.
+     * Handlers of the resulting annotation are ordered in the same way as given annotations. No deduplication takes place.
+     * <p>
+     * If a single annotation is given, then it is simply returned back.
+     *
+     * @param annotations {@link BeforeChange} instances to be merged
+     * @return merged instance of the {@link BeforeChange} annotation
+     */
+    public static BeforeChange merged(final BeforeChange... annotations) {
+        if (annotations.length == 1) return annotations[0];
+        final Handler[] handlers = Arrays.stream(annotations).flatMap(bch -> Arrays.stream(bch.value())).toArray(Handler[]::new);
         return new BeforeChangeAnnotation(handlers).newInstance();
     }
 
@@ -50,4 +67,5 @@ public class BeforeChangeAnnotation {
             }
         };
     }
+
 }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/annotation/factory/BeforeChangeAnnotation.java
@@ -17,6 +17,10 @@ public class BeforeChangeAnnotation {
         this.value = value;
     }
 
+    public static BeforeChange from(final Handler... handlers) {
+        return new BeforeChangeAnnotation(handlers).newInstance();
+    }
+
     public BeforeChange newInstance() {
         return new BeforeChange() {
 

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/exceptions/InvalidArgumentException.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/exceptions/InvalidArgumentException.java
@@ -1,0 +1,33 @@
+package ua.com.fielden.platform.entity.exceptions;
+
+import ua.com.fielden.platform.exceptions.AbstractPlatformRuntimeException;
+
+/**
+ * A runtime exception, which should be used to indicate invalid method arguments. 
+ * 
+ * @author TG Team
+ *
+ */
+public class InvalidArgumentException extends AbstractPlatformRuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * A convenient factory method that either create a new instance of {@code InvalidArgumentException} or returns {@code cause} if it is already of this type.
+     * 
+     * @param msg
+     * @param cause
+     * @return
+     */
+    public static InvalidArgumentException wrapIfNecessary(final String msg, final Exception cause) {
+        return cause instanceof InvalidArgumentException ? (InvalidArgumentException) cause : new InvalidArgumentException(msg, cause);
+    }
+
+    public InvalidArgumentException(final String msg) {
+        super(msg);
+    }
+
+    public InvalidArgumentException(final String msg, final Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/ioc/ObservableMutatorInterceptor.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/ioc/ObservableMutatorInterceptor.java
@@ -225,13 +225,13 @@ public class ObservableMutatorInterceptor implements MethodInterceptor {
                 // set previous value and recalculate meta-property properties based on the new value
                 metaProperty.setPrevValue(prevValue);
                 metaProperty.define(newValue);
-                
+
                 // determine property and entity dirty state
                 if (!metaProperty.isCalculated() && metaProperty.getValueChangeCount() > 0) {
                     metaProperty.setDirty(metaProperty.isChangedFromOriginal());
                     entity.setDirty(entity.isDirty() || metaProperty.isDirty());
                 }
-                
+
                 // handle updating of the dependent properties (dependent properties error recovery).
                 handleDependentProperties(metaProperty);
                 return setterResult.getSetterReturningValue();
@@ -324,7 +324,7 @@ public class ObservableMutatorInterceptor implements MethodInterceptor {
     /**
      * If there are some dependent properties for 'metaProperty' then all of the invalid dependent properties need to be attempted at reassigning the <code>lastAttamptedValue</code>,
      * and all valid dependencies need to be revalidated.
-     * 
+     *
      *
      * @param metaProperty
      */
@@ -342,8 +342,8 @@ public class ObservableMutatorInterceptor implements MethodInterceptor {
 
     /**
      * Enforces setting of the last attempted value or performs revalidation of the dependent property.
-     * This happens only if neither the dependent nor the driving property is on each other's dependency path. 
-     * 
+     * This happens only if neither the dependent nor the driving property is on each other's dependency path.
+     *
      * @param metaProperty
      * @param dependentMetaProperty
      */
@@ -361,7 +361,7 @@ public class ObservableMutatorInterceptor implements MethodInterceptor {
             }
         }
     }
-    
+
     /**
      * Determines correct newValue and oldValue. {@link Pair} is used to return a pair of values where the key represents newValue and the value represents oldValue.
      *

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictCommasValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictCommasValidator.java
@@ -1,5 +1,8 @@
 package ua.com.fielden.platform.entity.validation;
 
+import static ua.com.fielden.platform.error.Result.failure;
+import static ua.com.fielden.platform.error.Result.successful;
+
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
@@ -9,18 +12,18 @@ import ua.com.fielden.platform.error.Result;
 /**
  * A validator that restricts commas ({@code ','} characters) in a {@code String}-typed property.
  *
- * @author homedirectory
+ * @author TG Team
  */
 public class RestrictCommasValidator implements IBeforeChangeEventHandler<String> {
-    public static final String ERR_CONTAINS_COMMAS = "Value contains commas.";
+    public static final String ERR_CONTAINS_COMMAS = "Commas are not permitted.";
 
     @Override
     public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
         if (newValue != null && newValue.contains(",")) {
-            return Result.failure(ERR_CONTAINS_COMMAS);
+            return failure(ERR_CONTAINS_COMMAS);
         }
 
-        return Result.successful(newValue);
+        return successful(newValue);
     }
 
 }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictCommasValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictCommasValidator.java
@@ -1,0 +1,26 @@
+package ua.com.fielden.platform.entity.validation;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.error.Result;
+
+/**
+ * A validator that restricts commas ({@code ','} characters) in a {@code String}-typed property.
+ *
+ * @author homedirectory
+ */
+public class RestrictCommasValidator implements IBeforeChangeEventHandler<String> {
+    public static final String ERR_CONTAINS_COMMAS = "Value contains commas.";
+
+    @Override
+    public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
+        if (newValue != null && newValue.contains(",")) {
+            return Result.failure(ERR_CONTAINS_COMMAS);
+        }
+
+        return Result.successful(newValue);
+    }
+
+}

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidator.java
@@ -1,7 +1,9 @@
 package ua.com.fielden.platform.entity.validation;
 
 import static java.lang.String.format;
-import static ua.com.fielden.platform.types.tuples.T2.t2;
+import static ua.com.fielden.platform.error.Result.failure;
+import static ua.com.fielden.platform.error.Result.successful;
+import static ua.com.fielden.platform.types.tuples.T3.t3;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
@@ -16,17 +18,17 @@ import ua.com.fielden.platform.error.Result;
  * A validator that restricts extra whitespace in a {@code String}-typed property.
  * Extra whitespace includes: leading, trailing or consecutive (2 or more whitespace characters between non-whitespace).
  *
- * @author homedirectory
+ * @author TG Team
  */
 public class RestrictExtraWhitespaceValidator implements IBeforeChangeEventHandler<String> {
-    public static final String ERR_CONTAINS_LEADING_WHITESPACE = "Value contains leading whitespace.";
-    public static final String ERR_CONTAINS_LEADING_WHITESPACE_VALUE = "Value contains leading whitespace: [%s]";
+    public static final String ERR_CONTAINS_LEADING_WHITESPACE = "Leading whitespace characters are not perimtted.";
+    public static final String ERR_CONTAINS_LEADING_WHITESPACE_VALUE = "Leading whitespace characters are not perimtted: [%s]";
 
-    public static final String ERR_CONTAINS_TRAILING_WHITESPACE = "Value contains trailing whitespace.";
-    public static final String ERR_CONTAINS_TRAILING_WHITESPACE_VALUE = "Value contains trailing whitespace: [%s]";
+    public static final String ERR_CONTAINS_TRAILING_WHITESPACE = "Trailing whitespace characters are not perimtted.";
+    public static final String ERR_CONTAINS_TRAILING_WHITESPACE_VALUE = "Trailing whitespace characters are not perimtted: [%s]";
 
-    public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE = "Value contains consecutive whitespace.";
-    public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE = "Value contains consecutive whitespace: [%s]";
+    public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE = "Consecutive whitespace characters are not permitted.";
+    public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE = "Consecutive whitespace characters are not permitted: [%s]";
 
     private static final Pattern PATTERN_LEADING_WHITESPACE = Pattern.compile("^\\s+");
     private static final Pattern PATTERN_TRAILING_WHITESPACE = Pattern.compile("\\s+$");
@@ -39,32 +41,32 @@ public class RestrictExtraWhitespaceValidator implements IBeforeChangeEventHandl
     @Override
     public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
         if (newValue == null) {
-            return Result.successful(newValue);
+            return successful(newValue);
         }
 
         return Stream.of(
-                t2(PATTERN_LEADING_WHITESPACE, t2(ERR_CONTAINS_LEADING_WHITESPACE, ERR_CONTAINS_LEADING_WHITESPACE_VALUE)),
-                t2(PATTERN_TRAILING_WHITESPACE, t2(ERR_CONTAINS_TRAILING_WHITESPACE, ERR_CONTAINS_TRAILING_WHITESPACE_VALUE)),
-                t2(PATTERN_CONSECUTIVE_WHITESPACE, t2(ERR_CONTAINS_CONSECUTIVE_WHITESPACE, ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE)))
-                .map(p -> check(newValue, p._1, p._2._1, p._2._2))
+                t3(PATTERN_LEADING_WHITESPACE, ERR_CONTAINS_LEADING_WHITESPACE, ERR_CONTAINS_LEADING_WHITESPACE_VALUE),
+                t3(PATTERN_TRAILING_WHITESPACE, ERR_CONTAINS_TRAILING_WHITESPACE, ERR_CONTAINS_TRAILING_WHITESPACE_VALUE),
+                t3(PATTERN_CONSECUTIVE_WHITESPACE, ERR_CONTAINS_CONSECUTIVE_WHITESPACE, ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE))
+                .map(p -> check(newValue, p._1, p._2, p._3))
                 // find first match and return its result, otherwise return success
                 .filter(res -> !res.isSuccessfulWithoutWarningAndInformative())
-                .findFirst().orElse(Result.successful(newValue));
+                .findFirst().orElse(successful(newValue));
     }
 
     private static Result check(final String value, final Pattern pattern, final String message, final String messageWithValue) {
         final Matcher matcher = pattern.matcher(value);
 
         if (!matcher.find()) {
-            return Result.successful(value);
+            return successful(value);
         }
 
         if (value.length() >= MAX_REPORTABLE_LENGTH) {
-            return Result.failure(message);
+            return failure(message);
         }
 
         final String reportValue = matcher.replaceAll(WHITESPACE_REPLACEMENT);
-        return Result.failure(format(messageWithValue, reportValue));
+        return failure(format(messageWithValue, reportValue));
     }
 
 }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidator.java
@@ -21,11 +21,11 @@ import ua.com.fielden.platform.error.Result;
  * @author TG Team
  */
 public class RestrictExtraWhitespaceValidator implements IBeforeChangeEventHandler<String> {
-    public static final String ERR_CONTAINS_LEADING_WHITESPACE = "Leading whitespace characters are not perimtted.";
-    public static final String ERR_CONTAINS_LEADING_WHITESPACE_VALUE = "Leading whitespace characters are not perimtted: [%s]";
+    public static final String ERR_CONTAINS_LEADING_WHITESPACE = "Leading whitespace characters are not permitted.";
+    public static final String ERR_CONTAINS_LEADING_WHITESPACE_VALUE = "Leading whitespace characters are not permitted: [%s]";
 
-    public static final String ERR_CONTAINS_TRAILING_WHITESPACE = "Trailing whitespace characters are not perimtted.";
-    public static final String ERR_CONTAINS_TRAILING_WHITESPACE_VALUE = "Trailing whitespace characters are not perimtted: [%s]";
+    public static final String ERR_CONTAINS_TRAILING_WHITESPACE = "Trailing whitespace characters are not permitted.";
+    public static final String ERR_CONTAINS_TRAILING_WHITESPACE_VALUE = "Trailing whitespace characters are not permitted: [%s]";
 
     public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE = "Consecutive whitespace characters are not permitted.";
     public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE = "Consecutive whitespace characters are not permitted: [%s]";

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidator.java
@@ -1,0 +1,70 @@
+package ua.com.fielden.platform.entity.validation;
+
+import static java.lang.String.format;
+import static ua.com.fielden.platform.types.tuples.T2.t2;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.error.Result;
+
+/**
+ * A validator that restricts extra whitespace in a {@code String}-typed property.
+ * Extra whitespace includes: leading, trailing or consecutive (2 or more whitespace characters between non-whitespace).
+ *
+ * @author homedirectory
+ */
+public class RestrictExtraWhitespaceValidator implements IBeforeChangeEventHandler<String> {
+    public static final String ERR_CONTAINS_LEADING_WHITESPACE = "Value contains leading whitespace.";
+    public static final String ERR_CONTAINS_LEADING_WHITESPACE_VALUE = "Value contains leading whitespace: [%s]";
+
+    public static final String ERR_CONTAINS_TRAILING_WHITESPACE = "Value contains trailing whitespace.";
+    public static final String ERR_CONTAINS_TRAILING_WHITESPACE_VALUE = "Value contains trailing whitespace: [%s]";
+
+    public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE = "Value contains consecutive whitespace.";
+    public static final String ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE = "Value contains consecutive whitespace: [%s]";
+
+    private static final Pattern PATTERN_LEADING_WHITESPACE = Pattern.compile("^\\s+");
+    private static final Pattern PATTERN_TRAILING_WHITESPACE = Pattern.compile("\\s+$");
+    // this pattern does not strictly match between non-whitespace characters, but if checked last, it will do the trick
+    private static final Pattern PATTERN_CONSECUTIVE_WHITESPACE = Pattern.compile("\\s{2,}");
+
+    private static final String WHITESPACE_REPLACEMENT = "{?}";
+    public static final int MAX_REPORTABLE_LENGTH = 64;
+
+    @Override
+    public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
+        if (newValue == null) {
+            return Result.successful(newValue);
+        }
+
+        return Stream.of(
+                t2(PATTERN_LEADING_WHITESPACE, t2(ERR_CONTAINS_LEADING_WHITESPACE, ERR_CONTAINS_LEADING_WHITESPACE_VALUE)),
+                t2(PATTERN_TRAILING_WHITESPACE, t2(ERR_CONTAINS_TRAILING_WHITESPACE, ERR_CONTAINS_TRAILING_WHITESPACE_VALUE)),
+                t2(PATTERN_CONSECUTIVE_WHITESPACE, t2(ERR_CONTAINS_CONSECUTIVE_WHITESPACE, ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE)))
+                .map(p -> check(newValue, p._1, p._2._1, p._2._2))
+                // find first match and return its result, otherwise return success
+                .filter(res -> !res.isSuccessfulWithoutWarningAndInformative())
+                .findFirst().orElse(Result.successful(newValue));
+    }
+
+    private static Result check(final String value, final Pattern pattern, final String message, final String messageWithValue) {
+        final Matcher matcher = pattern.matcher(value);
+
+        if (!matcher.find()) {
+            return Result.successful(value);
+        }
+
+        if (value.length() >= MAX_REPORTABLE_LENGTH) {
+            return Result.failure(message);
+        }
+
+        final String reportValue = matcher.replaceAll(WHITESPACE_REPLACEMENT);
+        return Result.failure(format(messageWithValue, reportValue));
+    }
+
+}

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
@@ -1,5 +1,9 @@
 package ua.com.fielden.platform.entity.validation;
 
+import static java.lang.String.format;
+import static ua.com.fielden.platform.error.Result.failure;
+import static ua.com.fielden.platform.error.Result.successful;
+
 import java.lang.annotation.Annotation;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -18,11 +22,11 @@ import ua.com.fielden.platform.error.Result;
  *   <li>a single space</li>
  * </ul>
  *
- * @author homedirectory
+ * @author TG Team
  */
 public class RestrictNonPrintableCharactersValidator implements IBeforeChangeEventHandler<String> {
-    public static final String ERR_CONTAINS_NON_PRINTABLE = "Value contains non-printable characters.";
-    public static final String ERR_CONTAINS_NON_PRINTABLE_VALUE = "Value contains non-printable characters: [%s]";
+    public static final String ERR_CONTAINS_NON_PRINTABLE = "Non-printable characters are not permitted.";
+    public static final String ERR_CONTAINS_NON_PRINTABLE_VALUE = "Non-printable characters are not permitted: [%s]";
 
     private static final Pattern PATTERN_NON_PRINTABLE = Pattern.compile("[^\\p{Print}]");
     private static final String NON_PRINTABLE_REPLACEMENT = "{?}";
@@ -31,21 +35,21 @@ public class RestrictNonPrintableCharactersValidator implements IBeforeChangeEve
     @Override
     public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
         if (newValue == null) {
-            return Result.successful(newValue);
+            return successful(newValue);
         }
 
         final Matcher matcher = PATTERN_NON_PRINTABLE.matcher(newValue);
 
         if (!matcher.find()) {
-            return Result.successful(newValue);
+            return successful(newValue);
         }
 
         if (newValue.length() >= MAX_REPORTABLE_LENGTH) {
-            return Result.failure(ERR_CONTAINS_NON_PRINTABLE);
+            return failure(ERR_CONTAINS_NON_PRINTABLE);
         }
 
         final String reportValue = matcher.replaceAll(NON_PRINTABLE_REPLACEMENT);
-        return Result.failure(String.format(ERR_CONTAINS_NON_PRINTABLE_VALUE, reportValue));
+        return failure(format(ERR_CONTAINS_NON_PRINTABLE_VALUE, reportValue));
     }
 
 }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
@@ -6,21 +6,17 @@ import static ua.com.fielden.platform.error.Result.successful;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import com.google.common.base.CharMatcher;
 
 import ua.com.fielden.platform.entity.meta.MetaProperty;
 import ua.com.fielden.platform.error.Result;
 
 /**
- * A validator that restricts non-printable characters in a {@code String}-typed property.
+ * A validator that restricts invisible/non-printable characters, except a space, in a {@code String}-typed property.
  * <p>
- * Printable characters include:
- * <ul>
- *   <li>alphanumeric characters</li>
- *   <li>punctuation: one of <code>!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~</code> </li>
- *   <li>a single space</li>
- * </ul>
+ * The definition of invisible/non-printable characters is as per Google Guava's {@link CharMatcher#invisible()}.
+ * Strictly speaking this means that it would only work for BMP characters, but not for supplementary characters (e.g., emoji would get recognised as non-printable, which is suitable for the purpose of restricting key values).
  *
  * @author TG Team
  */
@@ -28,19 +24,19 @@ public class RestrictNonPrintableCharactersValidator implements IBeforeChangeEve
     public static final String ERR_CONTAINS_NON_PRINTABLE = "Non-printable characters are not permitted.";
     public static final String ERR_CONTAINS_NON_PRINTABLE_VALUE = "Non-printable characters are not permitted: [%s]";
 
-    private static final Pattern PATTERN_NON_PRINTABLE = Pattern.compile("[^\\p{Print}]");
     private static final String NON_PRINTABLE_REPLACEMENT = "{?}";
     public static final int MAX_REPORTABLE_LENGTH = 64;
 
+    private static final CharMatcher MATCHER = CharMatcher.invisible().and(CharMatcher.isNot(' ')).precomputed();
+    
     @Override
     public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
         if (newValue == null) {
             return successful(newValue);
         }
 
-        final Matcher matcher = PATTERN_NON_PRINTABLE.matcher(newValue);
-
-        if (!matcher.find()) {
+        
+        if (MATCHER.matchesNoneOf(newValue)) {
             return successful(newValue);
         }
 
@@ -48,7 +44,7 @@ public class RestrictNonPrintableCharactersValidator implements IBeforeChangeEve
             return failure(ERR_CONTAINS_NON_PRINTABLE);
         }
 
-        final String reportValue = matcher.replaceAll(NON_PRINTABLE_REPLACEMENT);
+        final String reportValue = MATCHER.replaceFrom(newValue, NON_PRINTABLE_REPLACEMENT);
         return failure(format(ERR_CONTAINS_NON_PRINTABLE_VALUE, reportValue));
     }
 

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
@@ -35,7 +35,6 @@ public class RestrictNonPrintableCharactersValidator implements IBeforeChangeEve
             return successful(newValue);
         }
 
-        
         if (MATCHER.matchesNoneOf(newValue)) {
             return successful(newValue);
         }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidator.java
@@ -1,0 +1,51 @@
+package ua.com.fielden.platform.entity.validation;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.error.Result;
+
+/**
+ * A validator that restricts non-printable characters in a {@code String}-typed property.
+ * <p>
+ * Printable characters include:
+ * <ul>
+ *   <li>alphanumeric characters</li>
+ *   <li>punctuation: one of <code>!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~</code> </li>
+ *   <li>a single space</li>
+ * </ul>
+ *
+ * @author homedirectory
+ */
+public class RestrictNonPrintableCharactersValidator implements IBeforeChangeEventHandler<String> {
+    public static final String ERR_CONTAINS_NON_PRINTABLE = "Value contains non-printable characters.";
+    public static final String ERR_CONTAINS_NON_PRINTABLE_VALUE = "Value contains non-printable characters: [%s]";
+
+    private static final Pattern PATTERN_NON_PRINTABLE = Pattern.compile("[^\\p{Print}]");
+    private static final String NON_PRINTABLE_REPLACEMENT = "{?}";
+    public static final int MAX_REPORTABLE_LENGTH = 64;
+
+    @Override
+    public Result handle(final MetaProperty<String> property, final String newValue, final Set<Annotation> mutatorAnnotations) {
+        if (newValue == null) {
+            return Result.successful(newValue);
+        }
+
+        final Matcher matcher = PATTERN_NON_PRINTABLE.matcher(newValue);
+
+        if (!matcher.find()) {
+            return Result.successful(newValue);
+        }
+
+        if (newValue.length() >= MAX_REPORTABLE_LENGTH) {
+            return Result.failure(ERR_CONTAINS_NON_PRINTABLE);
+        }
+
+        final String reportValue = matcher.replaceAll(NON_PRINTABLE_REPLACEMENT);
+        return Result.failure(String.format(ERR_CONTAINS_NON_PRINTABLE_VALUE, reportValue));
+    }
+
+}

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/reflection/Finder.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/reflection/Finder.java
@@ -239,7 +239,7 @@ public class Finder {
 
     /**
      * A stream equivalent to method {@link #findProperties(Class, Class...)}.
-     * 
+     *
      * @param entityType
      * @param annotations
      * @return
@@ -270,7 +270,7 @@ public class Finder {
 
     /**
      * A stream equivalent to method {@link #findRealProperties(Class, Class...)}.
-     * 
+     *
      * @param entityType
      * @param annotations
      * @return
@@ -445,10 +445,10 @@ public class Finder {
         }
         throw new ReflectionException(format("Failed to locate field [%s] in type [%s]", name, type.getName()));
     }
-    
+
     /**
      * The same as {@link #getFieldByName(Class, String)}, but side effect free.
-     * 
+     *
      * @param type
      * @param name
      * @return
@@ -486,10 +486,10 @@ public class Finder {
         final Pair<Class<?>, String> transformed = PropertyTypeDeterminator.transform(type, dotNotationExp);
         return getFieldByName(transformed.getKey(), transformed.getValue());
     }
-    
+
     /**
      * The same as {@link Finder#findFieldByName(Class, String)}, but side effect free.
-     * 
+     *
      * @param type
      * @param dotNotationExp
      * @return
@@ -519,7 +519,7 @@ public class Finder {
         Object value = entity;
         for (final String propName : propNames) {
             value = getPropertyValue((AbstractEntity<?>) value, propName);
-            
+
             if (value == null) {
                 return null;
             }
@@ -594,7 +594,7 @@ public class Finder {
 
     /**
      * Traces through specified list of fields and returns a stream of those annotated with allAnnotations.
-     * 
+     *
      * @param fields
      * @param allAnnotations
      * @return

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/reflection/Finder.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/reflection/Finder.java
@@ -665,7 +665,7 @@ public class Finder {
         return propertiesWithKeys;
     }
 
-    private static boolean isKey(final Field field) {
+    public static boolean isKey(final Field field) {
         return field.getName().equals(AbstractEntity.KEY) || field.isAnnotationPresent(CompositeKeyMember.class);
     }
 

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/utils/CollectionUtil.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/utils/CollectionUtil.java
@@ -17,15 +17,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import ua.com.fielden.platform.entity.AbstractEntity;
 import ua.com.fielden.platform.types.tuples.T2;
 
 /**
  * A convenience class to provide common collection related routines and algorithms.
- * 
+ *
  * @author TG Team
- * 
+ *
  */
 public final class CollectionUtil {
     private CollectionUtil() {
@@ -40,17 +41,17 @@ public final class CollectionUtil {
     public static <T> Set<T> unmodifiableSetOf(final T ... elements) {
         return unmodifiableSet(new HashSet<>(Arrays.asList(elements)));
     }
-    
+
     @SafeVarargs
     public static <T> LinkedHashSet<T> linkedSetOf(final T ... elements) {
         return new LinkedHashSet<>(Arrays.asList(elements));
     }
-    
+
     @SafeVarargs
     public static <T> List<T> listOf(final T ... elements) {
         return elements != null ? new ArrayList<>(asList(elements)) : emptyList();
     }
-    
+
     @SafeVarargs
     public static <T> List<T> unmodifiableListOf(final T ... elements) {
         return unmodifiableList(asList(elements));
@@ -76,7 +77,7 @@ public final class CollectionUtil {
 
     /**
      * A convenient method to obtain a tail of an array. Returns an empty optional if the length of arrays is 0.
-     * 
+     *
      * @param array
      * @return
      */
@@ -113,6 +114,24 @@ public final class CollectionUtil {
             buffer.append(value + (iter.hasNext() ? separator : ""));
         }
         return buffer.toString();
+    }
+
+    /**
+     * Removes the first element matching the predicate from the collection and returns an Optional describing it,
+     * otherwise returns an empty Optional. The supplied collection must be modifiable.
+     */
+    public static <E> Optional<E> removeFirst(final Collection<E> coll, final Predicate<E> pred) {
+        final Iterator<E> iter = coll.iterator();
+        E elt;
+        while (iter.hasNext()) {
+            elt = iter.next();
+            if (pred.test(elt)) {
+                iter.remove();
+                return Optional.of(elt);
+            }
+        }
+
+        return Optional.empty();
     }
 
 }

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/utils/CollectionUtil.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/utils/CollectionUtil.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.exceptions.InvalidArgumentException;
 import ua.com.fielden.platform.types.tuples.T2;
 
 /**
@@ -117,14 +118,28 @@ public final class CollectionUtil {
     }
 
     /**
-     * Removes the first element matching the predicate from the collection and returns an Optional describing it,
-     * otherwise returns an empty Optional. The supplied collection must be modifiable.
+     * Removes the first element matching the predicate from the collection and returns an {@link Optional} describing it, otherwise returns an empty {@link Optional}.
+     * <p>
+     * The supplied collection must be modifiable.
+     *
+     * @param <E> a type of elements in {@code xs}.
+     * @param xs a modifiable collection, which gets modified by removing the first element matching {@code pred}.
+     * @param pred a predicate for identifying the first element to be removed from {@code xs}.
+     * @return
      */
-    public static <E> Optional<E> removeFirst(final Collection<E> coll, final Predicate<E> pred) {
-        final Iterator<E> iter = coll.iterator();
-        E elt;
-        while (iter.hasNext()) {
-            elt = iter.next();
+    public static <E> Optional<E> removeFirst(final Collection<E> xs, final Predicate<E> pred) {
+        if (xs == null) {
+            throw new InvalidArgumentException("Collection cannot be null.");
+        }
+        if (pred == null) {
+            throw new InvalidArgumentException("Predicate cannot be null.");
+        }
+
+        for (final Iterator<E> iter = xs.iterator(); iter.hasNext();) {
+            final E elt = iter.next();
+            if (elt == null) {
+                throw new InvalidArgumentException("Collection contains null elements, which is not permitted.");
+            }
             if (pred.test(elt)) {
                 iter.remove();
                 return Optional.of(elt);

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/utils/CollectionUtil.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/utils/CollectionUtil.java
@@ -120,14 +120,14 @@ public final class CollectionUtil {
     /**
      * Removes the first element matching the predicate from the collection and returns an {@link Optional} describing it, otherwise returns an empty {@link Optional}.
      * <p>
-     * The supplied collection must be modifiable.
+     * The supplied collection must be modifiable and must not contain {@code null} values.
      *
      * @param <E> a type of elements in {@code xs}.
      * @param xs a modifiable collection, which gets modified by removing the first element matching {@code pred}.
      * @param pred a predicate for identifying the first element to be removed from {@code xs}.
      * @return
      */
-    public static <E> Optional<E> removeFirst(final Collection<E> xs, final Predicate<E> pred) {
+    public static <E> Optional<E> removeFirst(final Collection<E> xs, final Predicate<? super E> pred) {
         if (xs == null) {
             throw new InvalidArgumentException("Collection cannot be null.");
         }

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictCommasValidatorTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictCommasValidatorTest.java
@@ -1,0 +1,49 @@
+package ua.com.fielden.platform.entity.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static ua.com.fielden.platform.entity.validation.RestrictCommasValidator.ERR_CONTAINS_COMMAS;
+
+import java.util.function.Consumer;
+
+import org.junit.Test;
+
+import com.google.inject.Injector;
+
+import ua.com.fielden.platform.entity.factory.EntityFactory;
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.entity.validation.test_entities.EntityWithRestrictCommasValidation;
+import ua.com.fielden.platform.error.Result;
+import ua.com.fielden.platform.ioc.ApplicationInjectorFactory;
+import ua.com.fielden.platform.test.CommonTestEntityModuleWithPropertyFactory;
+import ua.com.fielden.platform.test.EntityModuleWithPropertyFactory;
+
+/**
+ * A test case for validation with {@link RestrictCommasValidator}.
+ *
+ * @author TG Team
+ */
+public class RestrictCommasValidatorTest {
+
+    private final EntityModuleWithPropertyFactory module = new CommonTestEntityModuleWithPropertyFactory();
+    private final Injector injector = new ApplicationInjectorFactory().add(module).getInjector();
+    private final EntityFactory factory = injector.getInstance(EntityFactory.class);
+
+    @Test
+    public void string_property_value_cannot_contain_commas() {
+        final EntityWithRestrictCommasValidation entity = factory.newEntity(EntityWithRestrictCommasValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final Consumer<String> assertor = newValue -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(ERR_CONTAINS_COMMAS, ff.getMessage());
+        };
+
+        assertor.accept(",");
+        assertor.accept("commas,are");
+        assertor.accept("commas,are,scary,,");
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidatorTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictExtraWhitespaceValidatorTest.java
@@ -1,0 +1,141 @@
+package ua.com.fielden.platform.entity.validation;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_CONSECUTIVE_WHITESPACE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_LEADING_WHITESPACE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_LEADING_WHITESPACE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_TRAILING_WHITESPACE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_TRAILING_WHITESPACE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator.MAX_REPORTABLE_LENGTH;
+
+import java.util.function.BiConsumer;
+
+import org.junit.Test;
+
+import com.google.inject.Injector;
+
+import ua.com.fielden.platform.entity.factory.EntityFactory;
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.entity.validation.test_entities.EntityWithRestrictExtraWhitespaceValidation;
+import ua.com.fielden.platform.error.Result;
+import ua.com.fielden.platform.ioc.ApplicationInjectorFactory;
+import ua.com.fielden.platform.test.CommonTestEntityModuleWithPropertyFactory;
+import ua.com.fielden.platform.test.EntityModuleWithPropertyFactory;
+
+/**
+ * A test case for validation with {@link RestrictExtraWhitespaceValidator}.
+ *
+ * @author TG Team
+ */
+public class RestrictExtraWhitespaceValidatorTest {
+
+    private final EntityModuleWithPropertyFactory module = new CommonTestEntityModuleWithPropertyFactory();
+    private final Injector injector = new ApplicationInjectorFactory().add(module).getInjector();
+    private final EntityFactory factory = injector.getInstance(EntityFactory.class);
+
+    @Test
+    public void string_property_value_cannot_contain_leading_whitespace() {
+        final EntityWithRestrictExtraWhitespaceValidation entity = factory.newEntity(EntityWithRestrictExtraWhitespaceValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept(" hello", "{?}hello");
+        assertor.accept("  hello", "{?}hello");
+        assertor.accept("\thello", "{?}hello");
+        assertor.accept("\nhello", "{?}hello");
+        assertor.accept("\rhello", "{?}hello");
+    }
+
+    @Test
+    public void leading_whitespace_validation_kicks_in_first() {
+        final EntityWithRestrictExtraWhitespaceValidation entity = factory.newEntity(EntityWithRestrictExtraWhitespaceValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept("  hello   world  ", "{?}hello   world  ");
+    }
+
+    @Test
+    public void string_property_value_cannot_contain_trailing_whitespace() {
+        final EntityWithRestrictExtraWhitespaceValidation entity = factory.newEntity(EntityWithRestrictExtraWhitespaceValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_TRAILING_WHITESPACE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept("hello ",  "hello{?}");
+        assertor.accept("hello  ", "hello{?}");
+        assertor.accept("hello\t", "hello{?}");
+        assertor.accept("hello\n", "hello{?}");
+        assertor.accept("hello\r", "hello{?}");
+    }
+
+    @Test
+    public void trailing_whitespace_validation_kicks_in_second() {
+        final EntityWithRestrictExtraWhitespaceValidation entity = factory.newEntity(EntityWithRestrictExtraWhitespaceValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_TRAILING_WHITESPACE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept("hello   world  ", "hello   world{?}");
+    }
+
+    @Test
+    public void string_property_value_cannot_contain_consecutive_whitespace() {
+        final EntityWithRestrictExtraWhitespaceValidation entity = factory.newEntity(EntityWithRestrictExtraWhitespaceValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept("hello  my     world",  "hello{?}my{?}world");
+        assertor.accept("hello\n\nworld",  "hello{?}world");
+    }
+
+    @Test
+    public void invalid_property_value_longer_than_the_limit_is_not_included_in_the_error_message() {
+        final EntityWithRestrictExtraWhitespaceValidation entity = factory.newEntity(EntityWithRestrictExtraWhitespaceValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, message) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(message, ff.getMessage());
+        };
+
+        assertor.accept(" " + repeat("x", MAX_REPORTABLE_LENGTH - 1), ERR_CONTAINS_LEADING_WHITESPACE);
+        assertor.accept(repeat("x", MAX_REPORTABLE_LENGTH - 1) + " ", ERR_CONTAINS_TRAILING_WHITESPACE);
+        assertor.accept(repeat("x", MAX_REPORTABLE_LENGTH - 1) + "a   b", ERR_CONTAINS_CONSECUTIVE_WHITESPACE);
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidatorTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidatorTest.java
@@ -53,6 +53,34 @@ public class RestrictNonPrintableCharactersValidatorTest {
     }
 
     @Test
+    public void string_property_value_cannot_contain_emoji_characters() {
+        final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_NON_PRINTABLE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept(format("That's a nice joke 😆", 0), "That's a nice joke {?}{?}"); // Emoji is represented by 2 characters, hence {?}{?} instead of {?}.
+    }
+
+    @Test
+    public void string_property_value_can_contain_non_ASCII_characters() {
+        final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        entity.setStringProp("Добрий день, ми з України!");
+        assertTrue(mp.isValid());
+        entity.setStringProp("你好，我们来自中国");
+        assertTrue(mp.isValid());
+        entity.setStringProp("Diese Mäuse ist aus Deutschland.");
+        assertTrue(mp.isValid());
+    }
+
+    @Test
     public void string_property_value_can_contain_regular_space_characters() {
         final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
         final MetaProperty<String> mp = entity.getProperty("stringProp");

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidatorTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/RestrictNonPrintableCharactersValidatorTest.java
@@ -1,0 +1,98 @@
+package ua.com.fielden.platform.entity.validation;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator.ERR_CONTAINS_NON_PRINTABLE;
+import static ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator.ERR_CONTAINS_NON_PRINTABLE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator.MAX_REPORTABLE_LENGTH;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import com.google.inject.Injector;
+
+import ua.com.fielden.platform.entity.factory.EntityFactory;
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.entity.validation.test_entities.EntityWithRestrictNonPrintableCharactersValidation;
+import ua.com.fielden.platform.error.Result;
+import ua.com.fielden.platform.ioc.ApplicationInjectorFactory;
+import ua.com.fielden.platform.test.CommonTestEntityModuleWithPropertyFactory;
+import ua.com.fielden.platform.test.EntityModuleWithPropertyFactory;
+
+/**
+ * A test case for validation with {@link RestrictNonPrintableCharactersValidator}.
+ *
+ * @author TG Team
+ */
+public class RestrictNonPrintableCharactersValidatorTest {
+
+    private final EntityModuleWithPropertyFactory module = new CommonTestEntityModuleWithPropertyFactory();
+    private final Injector injector = new ApplicationInjectorFactory().add(module).getInjector();
+    private final EntityFactory factory = injector.getInstance(EntityFactory.class);
+
+    @Test
+    public void string_property_value_cannot_contain_non_printable_characters() {
+        final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_NON_PRINTABLE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept(format("hello %c", 0), "hello {?}");
+        assertor.accept(format("%c hello %c", 0, 1), "{?} hello {?}");
+        assertor.accept(format("%c%c hel%clo", 0, 1, 2), "{?}{?} hel{?}lo");
+    }
+
+    @Test
+    public void string_property_value_can_contain_regular_space_characters() {
+        final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        entity.setStringProp("   hello   world    ");
+        assertTrue(mp.isValid());
+    }
+
+    @Test
+    public void string_property_value_cannot_contain_carriage_returns_or_newlines() {
+        final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final BiConsumer<String, String> assertor = (newValue, msgValue) -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(format(ERR_CONTAINS_NON_PRINTABLE_VALUE, msgValue), ff.getMessage());
+        };
+
+        assertor.accept("hello\nworld", "hello{?}world");
+        assertor.accept("hello\rworld", "hello{?}world");
+        assertor.accept("hello\r\nworld", "hello{?}{?}world");
+        assertor.accept("hello world\n", "hello world{?}");
+    }
+
+    @Test
+    public void invalid_property_value_longer_than_the_limit_is_not_included_in_the_error_message() {
+        final EntityWithRestrictNonPrintableCharactersValidation entity = factory.newEntity(EntityWithRestrictNonPrintableCharactersValidation.class);
+        final MetaProperty<String> mp = entity.getProperty("stringProp");
+
+        final Consumer<String> assertor = newValue -> {
+            entity.setStringProp(newValue);
+            final Result ff = mp.getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(ERR_CONTAINS_NON_PRINTABLE, ff.getMessage());
+        };
+
+        assertor.accept(format("%s%c", StringUtils.repeat("x", MAX_REPORTABLE_LENGTH), 0));
+        assertor.accept(format("%s%c", StringUtils.repeat("x", MAX_REPORTABLE_LENGTH - 1), 0));
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
@@ -1,0 +1,102 @@
+package ua.com.fielden.platform.entity.validation;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static ua.com.fielden.platform.entity.validation.RestrictCommasValidator.ERR_CONTAINS_COMMAS;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_LEADING_WHITESPACE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_TRAILING_WHITESPACE_VALUE;
+import static ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator.ERR_CONTAINS_NON_PRINTABLE_VALUE;
+import static ua.com.fielden.platform.entity.validators.RudeValidator.ERR_RUDE_MESSAGE;
+
+import java.util.function.BiConsumer;
+
+import org.junit.Test;
+
+import com.google.inject.Injector;
+
+import ua.com.fielden.platform.entity.factory.EntityFactory;
+import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKey;
+import ua.com.fielden.platform.error.Result;
+import ua.com.fielden.platform.ioc.ApplicationInjectorFactory;
+import ua.com.fielden.platform.test.CommonTestEntityModuleWithPropertyFactory;
+import ua.com.fielden.platform.test.EntityModuleWithPropertyFactory;
+
+/**
+ * A test case for validation of {@code String}-typed keys and key-members.
+ *
+ * @author TG Team
+ *
+ */
+public class StringKeysValidationTest {
+
+    private final EntityModuleWithPropertyFactory module = new CommonTestEntityModuleWithPropertyFactory();
+    private final Injector injector = new ApplicationInjectorFactory().add(module).getInjector();
+    private final EntityFactory factory = injector.getInstance(EntityFactory.class);
+
+    @Test
+    public void String_key_property_implicit_validators_are_applied_before_explicit_BeforeChange_handlers() {
+        final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
+
+        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
+            entity.setKey(newValue);
+            final Result ff = entity.getProperty("key").getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(errorMsg, ff.getMessage());
+        };
+
+        assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
+        assertor.accept("hello world", ERR_RUDE_MESSAGE);
+        assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
+    }
+
+    @Test
+    public void String_key_property_cannot_contain_extra_whitespace() {
+        final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
+
+        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
+            entity.setKey(newValue);
+            final Result ff = entity.getProperty("key").getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(errorMsg, ff.getMessage());
+        };
+
+        assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
+        assertor.accept("hello  ", format(ERR_CONTAINS_TRAILING_WHITESPACE_VALUE, "hello{?}"));
+        assertor.accept("hello   world", format(ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE, "hello{?}world"));
+    }
+
+    @Test
+    public void String_key_property_cannot_contain_non_printable_characters() {
+        final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
+
+        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
+            entity.setKey(newValue);
+            final Result ff = entity.getProperty("key").getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(errorMsg, ff.getMessage());
+        };
+
+        assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
+        assertor.accept(format("hello%c", 0), format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
+        assertor.accept(format("hello%c%cworld%c%c", 0, 0, 1, 1), format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}{?}world{?}{?}"));
+    }
+
+    @Test
+    public void String_key_property_cannot_contain_commas() {
+        final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
+
+        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
+            entity.setKey(newValue);
+            final Result ff = entity.getProperty("key").getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(errorMsg, ff.getMessage());
+        };
+
+        assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
+        assertor.accept(",hello world", ERR_CONTAINS_COMMAS);
+        assertor.accept("hello world,", ERR_CONTAINS_COMMAS);
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
@@ -107,7 +107,7 @@ public class StringKeysValidationTest {
     public void String_key_member_with_fully_skipped_validation_permits_non_printable_chars_consecutive_whitespace_chars_and_commas() {
         final EntityWithStringKeyMembersThatSkipDefaultStringValidation entity = factory.newEntity(EntityWithStringKeyMembersThatSkipDefaultStringValidation.class);
         final MetaProperty<String> mpMember1 = entity.getProperty("member1");
-        
+
         entity.setMember1(" hello\n world,  and some  ");
         assertTrue(mpMember1.isValid());
     }
@@ -126,14 +126,14 @@ public class StringKeysValidationTest {
     }
 
     @Test
-    public void String_key_member_with_skipped_validation_for_commas_and_consecuritve_whitespace_chars_restricts_only_non_printable_chars() {
+    public void String_key_member_with_skipped_validation_for_commas_and_consecutive_whitespace_chars_restricts_only_non_printable_chars() {
         final EntityWithStringKeyMembersThatSkipDefaultStringValidation entity = factory.newEntity(EntityWithStringKeyMembersThatSkipDefaultStringValidation.class);
         final String propName = "member3";
         final BiConsumer<String, String> assertor = mkAssertor(entity, propName);
 
         assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
 
-        entity.setMember3("  hello, world  ");
+        entity.setMember3("  hello,  world  ");
         assertTrue(entity.getProperty(propName).isValid());
     }
 

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
@@ -20,6 +20,7 @@ import com.google.inject.Injector;
 import ua.com.fielden.platform.entity.AbstractEntity;
 import ua.com.fielden.platform.entity.factory.EntityFactory;
 import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.entity.validation.test_entities.EntityWithImplicitStringKey;
 import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKey;
 import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKeyMember;
 import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKeyMembersThatSkipDefaultStringValidation;
@@ -46,6 +47,15 @@ public class StringKeysValidationTest {
         final BiConsumer<String, String> assertor = mkAssertor(entity, "key");
         assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
         assertor.accept("hello world", ERR_RUDE_MESSAGE);
+        assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
+    }
+
+    @Test
+    public void implicit_String_key_property_attacts_default_validation() {
+        final EntityWithImplicitStringKey entity = factory.newEntity(EntityWithImplicitStringKey.class);
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "key");
+        assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
+        assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
         assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
     }
 

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/StringKeysValidationTest.java
@@ -3,6 +3,7 @@ package ua.com.fielden.platform.entity.validation;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static ua.com.fielden.platform.entity.validation.RestrictCommasValidator.ERR_CONTAINS_COMMAS;
 import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE;
 import static ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator.ERR_CONTAINS_LEADING_WHITESPACE_VALUE;
@@ -16,9 +17,12 @@ import org.junit.Test;
 
 import com.google.inject.Injector;
 
+import ua.com.fielden.platform.entity.AbstractEntity;
 import ua.com.fielden.platform.entity.factory.EntityFactory;
+import ua.com.fielden.platform.entity.meta.MetaProperty;
 import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKey;
 import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKeyMember;
+import ua.com.fielden.platform.entity.validation.test_entities.EntityWithStringKeyMembersThatSkipDefaultStringValidation;
 import ua.com.fielden.platform.error.Result;
 import ua.com.fielden.platform.ioc.ApplicationInjectorFactory;
 import ua.com.fielden.platform.test.CommonTestEntityModuleWithPropertyFactory;
@@ -39,14 +43,7 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_property_implicit_validators_are_applied_before_explicit_BeforeChange_handlers() {
         final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setKey(newValue);
-            final Result ff = entity.getProperty("key").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "key");
         assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
         assertor.accept("hello world", ERR_RUDE_MESSAGE);
         assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
@@ -55,14 +52,7 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_member_property_implicit_validators_are_applied_before_explicit_BeforeChange_handlers() {
         final EntityWithStringKeyMember entity = factory.newEntity(EntityWithStringKeyMember.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setName(newValue);
-            final Result ff = entity.getProperty("name").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "name");
         assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
         assertor.accept("hello world", ERR_RUDE_MESSAGE);
         assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
@@ -71,14 +61,7 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_property_cannot_contain_extra_whitespace() {
         final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setKey(newValue);
-            final Result ff = entity.getProperty("key").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "key");
         assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
         assertor.accept("hello  ", format(ERR_CONTAINS_TRAILING_WHITESPACE_VALUE, "hello{?}"));
         assertor.accept("hello   world", format(ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE, "hello{?}world"));
@@ -87,14 +70,7 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_member_property_cannot_contain_extra_whitespace() {
         final EntityWithStringKeyMember entity = factory.newEntity(EntityWithStringKeyMember.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setName(newValue);
-            final Result ff = entity.getProperty("name").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "name");
         assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
         assertor.accept("hello  ", format(ERR_CONTAINS_TRAILING_WHITESPACE_VALUE, "hello{?}"));
         assertor.accept("hello   world", format(ERR_CONTAINS_CONSECUTIVE_WHITESPACE_VALUE, "hello{?}world"));
@@ -103,14 +79,7 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_property_cannot_contain_non_printable_characters() {
         final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setKey(newValue);
-            final Result ff = entity.getProperty("key").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "key");
         assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
         assertor.accept(format("hello%c", 0), format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
         assertor.accept(format("hello%c%cworld%c%c", 0, 0, 1, 1), format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}{?}world{?}{?}"));
@@ -119,14 +88,7 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_member_property_cannot_contain_non_printable_characters() {
         final EntityWithStringKeyMember entity = factory.newEntity(EntityWithStringKeyMember.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setName(newValue);
-            final Result ff = entity.getProperty("name").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "name");
         assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
         assertor.accept(format("hello%c", 0), format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
         assertor.accept(format("hello%c%cworld%c%c", 0, 0, 1, 1), format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}{?}world{?}{?}"));
@@ -135,17 +97,73 @@ public class StringKeysValidationTest {
     @Test
     public void String_key_property_cannot_contain_commas() {
         final EntityWithStringKey entity = factory.newEntity(EntityWithStringKey.class);
-
-        final BiConsumer<String, String> assertor = (newValue, errorMsg) -> {
-            entity.setKey(newValue);
-            final Result ff = entity.getProperty("key").getFirstFailure();
-            assertNotNull("Validation should have failed.", ff);
-            assertEquals(errorMsg, ff.getMessage());
-        };
-
+        final BiConsumer<String, String> assertor = mkAssertor(entity, "key");
         assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
         assertor.accept(",hello world", ERR_CONTAINS_COMMAS);
         assertor.accept("hello world,", ERR_CONTAINS_COMMAS);
+    }
+
+    @Test
+    public void String_key_member_with_fully_skipped_validation_permits_non_printable_chars_consecutive_whitespace_chars_and_commas() {
+        final EntityWithStringKeyMembersThatSkipDefaultStringValidation entity = factory.newEntity(EntityWithStringKeyMembersThatSkipDefaultStringValidation.class);
+        final MetaProperty<String> mpMember1 = entity.getProperty("member1");
+        
+        entity.setMember1(" hello\n world,  and some  ");
+        assertTrue(mpMember1.isValid());
+    }
+
+    @Test
+    public void String_key_member_with_skipped_validation_for_commas_permits_commas_but_not_non_printable_chars_or_consecutive_whitespace_chars() {
+        final EntityWithStringKeyMembersThatSkipDefaultStringValidation entity = factory.newEntity(EntityWithStringKeyMembersThatSkipDefaultStringValidation.class);
+        final String propName = "member2";
+        final BiConsumer<String, String> assertor = mkAssertor(entity, propName);
+
+        assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
+        assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
+
+        entity.setMember2("hello, world");
+        assertTrue(entity.getProperty(propName).isValid());
+    }
+
+    @Test
+    public void String_key_member_with_skipped_validation_for_commas_and_consecuritve_whitespace_chars_restricts_only_non_printable_chars() {
+        final EntityWithStringKeyMembersThatSkipDefaultStringValidation entity = factory.newEntity(EntityWithStringKeyMembersThatSkipDefaultStringValidation.class);
+        final String propName = "member3";
+        final BiConsumer<String, String> assertor = mkAssertor(entity, propName);
+
+        assertor.accept("hello\n", format(ERR_CONTAINS_NON_PRINTABLE_VALUE, "hello{?}"));
+
+        entity.setMember3("  hello, world  ");
+        assertTrue(entity.getProperty(propName).isValid());
+    }
+
+    @Test
+    public void String_key_member_with_skipped_validation_for_non_printable_chars_restricts_whitespace_chars_and_commas() {
+        final EntityWithStringKeyMembersThatSkipDefaultStringValidation entity = factory.newEntity(EntityWithStringKeyMembersThatSkipDefaultStringValidation.class);
+        final String propName = "member4";
+        final BiConsumer<String, String> assertor = mkAssertor(entity, propName);
+
+        assertor.accept("  hello", format(ERR_CONTAINS_LEADING_WHITESPACE_VALUE, "{?}hello"));
+        assertor.accept("hello,world", ERR_CONTAINS_COMMAS);
+
+        entity.setMember4("hello\\n");
+        assertTrue(entity.getProperty(propName).isValid());
+    }
+
+    /**
+     * A helper factory method to create an assertor for an entity and its property.
+     *
+     * @param entity
+     * @param propName
+     * @return
+     */
+    private static BiConsumer<String, String> mkAssertor(final AbstractEntity<?> entity, final String propName) {
+        return (newValue, errorMsg) -> {
+            entity.set(propName, newValue);
+            final Result ff = entity.getProperty(propName).getFirstFailure();
+            assertNotNull("Validation should have failed.", ff);
+            assertEquals(errorMsg, ff.getMessage());
+        };
     }
 
 }

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithImplicitStringKey.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithImplicitStringKey.java
@@ -1,0 +1,14 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+
+/**
+ * Test entity type with key of type {@link String}, which is implicit (i.e., there is no explicitly declared field {@code key} in this class).
+ *
+ * @author TG Team
+ */
+@KeyType(String.class)
+public class EntityWithImplicitStringKey extends AbstractEntity<String> {
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithRestrictCommasValidation.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithRestrictCommasValidation.java
@@ -1,0 +1,34 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.annotation.IsProperty;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+import ua.com.fielden.platform.entity.annotation.Observable;
+import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
+import ua.com.fielden.platform.entity.annotation.mutator.Handler;
+import ua.com.fielden.platform.entity.validation.RestrictCommasValidator;
+import ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator;
+
+/**
+ * Entity for testing of validator {@link RestrictExtraWhitespaceValidator}.
+ *
+ * @author TG Team
+ */
+@KeyType(String.class)
+public class EntityWithRestrictCommasValidation extends AbstractEntity<String> {
+
+    @IsProperty
+    @BeforeChange(@Handler(RestrictCommasValidator.class))
+    private String stringProp;
+
+    @Observable
+    public EntityWithRestrictCommasValidation setStringProp(final String prop) {
+        this.stringProp = prop;
+        return this;
+    }
+
+    public String getStringProp() {
+        return stringProp;
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithRestrictExtraWhitespaceValidation.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithRestrictExtraWhitespaceValidation.java
@@ -1,0 +1,33 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.annotation.IsProperty;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+import ua.com.fielden.platform.entity.annotation.Observable;
+import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
+import ua.com.fielden.platform.entity.annotation.mutator.Handler;
+import ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator;
+
+/**
+ * Entity for testing of validator {@link RestrictExtraWhitespaceValidator}.
+ *
+ * @author TG Team
+ */
+@KeyType(String.class)
+public class EntityWithRestrictExtraWhitespaceValidation extends AbstractEntity<String> {
+
+    @IsProperty
+    @BeforeChange(@Handler(RestrictExtraWhitespaceValidator.class))
+    private String stringProp;
+
+    @Observable
+    public EntityWithRestrictExtraWhitespaceValidation setStringProp(final String prop) {
+        this.stringProp = prop;
+        return this;
+    }
+
+    public String getStringProp() {
+        return stringProp;
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithRestrictNonPrintableCharactersValidation.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithRestrictNonPrintableCharactersValidation.java
@@ -1,0 +1,33 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.annotation.IsProperty;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+import ua.com.fielden.platform.entity.annotation.Observable;
+import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
+import ua.com.fielden.platform.entity.annotation.mutator.Handler;
+import ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator;
+
+/**
+ * Entity for testing of validator {@link RestrictNonPrintableCharactersValidator}.
+ *
+ * @author TG Team
+ */
+@KeyType(String.class)
+public class EntityWithRestrictNonPrintableCharactersValidation extends AbstractEntity<String> {
+
+    @IsProperty
+    @BeforeChange(@Handler(RestrictNonPrintableCharactersValidator.class))
+    private String stringProp;
+
+    @Observable
+    public EntityWithRestrictNonPrintableCharactersValidation setStringProp(final String prop) {
+        this.stringProp = prop;
+        return this;
+    }
+
+    public String getStringProp() {
+        return stringProp;
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKey.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKey.java
@@ -1,0 +1,37 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.annotation.IsProperty;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+import ua.com.fielden.platform.entity.annotation.MapTo;
+import ua.com.fielden.platform.entity.annotation.Observable;
+import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
+import ua.com.fielden.platform.entity.annotation.mutator.Handler;
+import ua.com.fielden.platform.entity.validators.RudeValidator;
+
+/**
+ * Test entity type with key of type {@link String}.
+ *
+ * @author TG Team
+ */
+@KeyType(String.class)
+public class EntityWithStringKey extends AbstractEntity<String> {
+
+    @IsProperty
+    @MapTo
+    @BeforeChange(@Handler(RudeValidator.class))
+    private String key;
+
+    @Override
+    @Observable
+    public EntityWithStringKey setKey(final String key) {
+        this.key = key;
+        return this;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKeyMember.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKeyMember.java
@@ -1,0 +1,38 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.DynamicEntityKey;
+import ua.com.fielden.platform.entity.annotation.CompositeKeyMember;
+import ua.com.fielden.platform.entity.annotation.IsProperty;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+import ua.com.fielden.platform.entity.annotation.MapTo;
+import ua.com.fielden.platform.entity.annotation.Observable;
+import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
+import ua.com.fielden.platform.entity.annotation.mutator.Handler;
+import ua.com.fielden.platform.entity.validators.RudeValidator;
+
+/**
+ * Test entity type with a key member of type {@link String}.
+ *
+ * @author TG Team
+ */
+@KeyType(DynamicEntityKey.class)
+public class EntityWithStringKeyMember extends AbstractEntity<DynamicEntityKey> {
+
+    @IsProperty
+    @MapTo
+    @CompositeKeyMember(1)
+    @BeforeChange(@Handler(RudeValidator.class))
+    private String name;
+
+    @Observable
+    public EntityWithStringKeyMember setName(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKeyMember.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKeyMember.java
@@ -5,7 +5,6 @@ import ua.com.fielden.platform.entity.DynamicEntityKey;
 import ua.com.fielden.platform.entity.annotation.CompositeKeyMember;
 import ua.com.fielden.platform.entity.annotation.IsProperty;
 import ua.com.fielden.platform.entity.annotation.KeyType;
-import ua.com.fielden.platform.entity.annotation.MapTo;
 import ua.com.fielden.platform.entity.annotation.Observable;
 import ua.com.fielden.platform.entity.annotation.mutator.BeforeChange;
 import ua.com.fielden.platform.entity.annotation.mutator.Handler;
@@ -20,7 +19,6 @@ import ua.com.fielden.platform.entity.validators.RudeValidator;
 public class EntityWithStringKeyMember extends AbstractEntity<DynamicEntityKey> {
 
     @IsProperty
-    @MapTo
     @CompositeKeyMember(1)
     @BeforeChange(@Handler(RudeValidator.class))
     private String name;

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKeyMembersThatSkipDefaultStringValidation.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validation/test_entities/EntityWithStringKeyMembersThatSkipDefaultStringValidation.java
@@ -1,0 +1,82 @@
+package ua.com.fielden.platform.entity.validation.test_entities;
+
+import ua.com.fielden.platform.entity.AbstractEntity;
+import ua.com.fielden.platform.entity.DynamicEntityKey;
+import ua.com.fielden.platform.entity.annotation.CompositeKeyMember;
+import ua.com.fielden.platform.entity.annotation.IsProperty;
+import ua.com.fielden.platform.entity.annotation.KeyType;
+import ua.com.fielden.platform.entity.annotation.Observable;
+import ua.com.fielden.platform.entity.annotation.SkipDefaultStringKeyMemberValidation;
+import ua.com.fielden.platform.entity.validation.RestrictCommasValidator;
+import ua.com.fielden.platform.entity.validation.RestrictExtraWhitespaceValidator;
+import ua.com.fielden.platform.entity.validation.RestrictNonPrintableCharactersValidator;
+
+/**
+ * Test entity type with multiple key members of type {@link String} and various skip annotations to relax the default string key validation.
+ *
+ * @author TG Team
+ */
+@KeyType(DynamicEntityKey.class)
+public class EntityWithStringKeyMembersThatSkipDefaultStringValidation extends AbstractEntity<DynamicEntityKey> {
+
+    @IsProperty
+    @CompositeKeyMember(1)
+    @SkipDefaultStringKeyMemberValidation
+    private String member1;
+
+    @IsProperty
+    @CompositeKeyMember(2)
+    @SkipDefaultStringKeyMemberValidation(RestrictCommasValidator.class)
+    private String member2;
+    
+    @IsProperty
+    @CompositeKeyMember(3)
+    @SkipDefaultStringKeyMemberValidation({RestrictCommasValidator.class, RestrictExtraWhitespaceValidator.class})
+    private String member3;
+
+    @IsProperty
+    @CompositeKeyMember(4)
+    @SkipDefaultStringKeyMemberValidation(RestrictNonPrintableCharactersValidator.class)
+    private String member4;
+
+    @Observable
+    public EntityWithStringKeyMembersThatSkipDefaultStringValidation setMember4(final String member4) {
+        this.member4 = member4;
+        return this;
+    }
+
+    public String getMember4() {
+        return member4;
+    }
+
+    @Observable
+    public EntityWithStringKeyMembersThatSkipDefaultStringValidation setMember3(final String member3) {
+        this.member3 = member3;
+        return this;
+    }
+
+    public String getMember3() {
+        return member3;
+    }
+
+    @Observable
+    public EntityWithStringKeyMembersThatSkipDefaultStringValidation setMember2(final String member2) {
+        this.member2 = member2;
+        return this;
+    }
+
+    public String getMember2() {
+        return member2;
+    }
+
+    @Observable
+    public EntityWithStringKeyMembersThatSkipDefaultStringValidation setMember1(final String name) {
+        this.member1 = name;
+        return this;
+    }
+
+    public String getMember1() {
+        return member1;
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validators/RudeValidator.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/entity/validators/RudeValidator.java
@@ -1,0 +1,24 @@
+package ua.com.fielden.platform.entity.validators;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import ua.com.fielden.platform.entity.meta.MetaProperty;
+import ua.com.fielden.platform.entity.validation.IBeforeChangeEventHandler;
+import ua.com.fielden.platform.error.Result;
+
+/**
+ * A validator for testing purposes that always fails with a rude message.
+ *
+ * @author TG Team
+ */
+public class RudeValidator implements IBeforeChangeEventHandler<Object> {
+
+    public static final String ERR_RUDE_MESSAGE = "Seriously? Don't even bother. Your values will never pass my validation.";
+
+    @Override
+    public Result handle(MetaProperty<Object> property, Object newValue, Set<Annotation> mutatorAnnotations) {
+        return Result.failure(ERR_RUDE_MESSAGE);
+    }
+
+}

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/utils/CollectionUtilTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/utils/CollectionUtilTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static ua.com.fielden.platform.types.tuples.T2.t2;
 import static ua.com.fielden.platform.utils.CollectionUtil.linkedMapOf;
@@ -18,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+
+import ua.com.fielden.platform.entity.exceptions.InvalidArgumentException;
 
 public class CollectionUtilTest {
 
@@ -85,16 +88,34 @@ public class CollectionUtilTest {
 
     @Test
     public void removeFirst_removes_only_the_first_element_matching_the_predicate() {
-        final List<Integer> list = listOf(1, 2, 3);
-        assertEquals(Integer.valueOf(2), removeFirst(list, x -> x >=2).get());
-        assertArrayEquals(new Integer[] {1, 3}, list.toArray());
+        final List<Integer> xs = listOf(1, 2, 3);
+        assertEquals(Integer.valueOf(2), removeFirst(xs, x -> x >=2).get());
+        assertEquals(listOf(1, 3), xs);
     }
 
     @Test
     public void removeFirst_removes_nothing_and_returns_empty_Optional_if_no_elements_match_the_predicate() {
-        final List<Integer> list = listOf(1, 2, 3);
-        assertFalse(removeFirst(list, x -> x < 0).isPresent());
-        assertArrayEquals(new Integer[] {1, 2, 3}, list.toArray());
+        final List<Integer> xs = listOf(1, 2, 3);
+        assertFalse(removeFirst(xs, x -> x < 0).isPresent());
+        assertEquals(listOf(1, 2, 3), xs);
+    }
+
+    @Test
+    public void removeFirst_passing_null_collection_throws_InvalidArgumentException() {
+        final List<Integer> xs = null;
+        assertThrows(InvalidArgumentException.class, () -> removeFirst(xs, x -> x >=2));
+    }
+
+    @Test
+    public void removeFirst_passing_null_predicate_throws_InvalidArgumentException() {
+        final List<Integer> xs = listOf(1, 2, 3);
+        assertThrows(InvalidArgumentException.class, () -> removeFirst(xs, null));
+    }
+
+    @Test
+    public void removeFirst_does_not_permit_null_elements_throwing_InvalidArgumentException() {
+        final List<Integer> xs = listOf(1, null, 3);
+        assertThrows(InvalidArgumentException.class, () -> removeFirst(xs, x -> x >=2));
     }
 
 }

--- a/platform-pojo-bl/src/test/java/ua/com/fielden/platform/utils/CollectionUtilTest.java
+++ b/platform-pojo-bl/src/test/java/ua/com/fielden/platform/utils/CollectionUtilTest.java
@@ -10,6 +10,7 @@ import static ua.com.fielden.platform.types.tuples.T2.t2;
 import static ua.com.fielden.platform.utils.CollectionUtil.linkedMapOf;
 import static ua.com.fielden.platform.utils.CollectionUtil.listOf;
 import static ua.com.fielden.platform.utils.CollectionUtil.mapOf;
+import static ua.com.fielden.platform.utils.CollectionUtil.removeFirst;
 import static ua.com.fielden.platform.utils.CollectionUtil.tail;
 
 import java.util.LinkedHashMap;
@@ -50,20 +51,20 @@ public class CollectionUtilTest {
         assertNotNull(mapOf());
         assertTrue(mapOf().isEmpty());
     }
-    
+
     @Test
     public void mapOf_produces_map_with_all_key_value_pairs_matching_arguments() {
         final Map<String, Integer> map = mapOf(t2("key1", 42), t2("key2", 12));
-        
+
         assertEquals(2, map.size());
         assertEquals(Integer.valueOf(42), map.get("key1"));
         assertEquals(Integer.valueOf(12), map.get("key2"));
     }
-    
+
     @Test
     public void linkedMapOf_produces_linked_map_with_all_key_value_pairs_matching_arguments() {
         final Map<String, Integer> map = linkedMapOf(t2("key1", 42), t2("key2", 12));
-        
+
         assertTrue(map instanceof LinkedHashMap);
         assertEquals(2, map.size());
         assertEquals(Integer.valueOf(42), map.get("key1"));
@@ -80,6 +81,20 @@ public class CollectionUtilTest {
         assertArrayEquals(new Integer[] {}, tail(new Integer[] {1}).get());
         assertArrayEquals(new Integer[] {2}, tail(new Integer[] {1, 2}).get());
         assertArrayEquals(new Integer[] {2, 3}, tail(new Integer[] {1, 2, 3}).get());
+    }
+
+    @Test
+    public void removeFirst_removes_only_the_first_element_matching_the_predicate() {
+        final List<Integer> list = listOf(1, 2, 3);
+        assertEquals(Integer.valueOf(2), removeFirst(list, x -> x >=2).get());
+        assertArrayEquals(new Integer[] {1, 3}, list.toArray());
+    }
+
+    @Test
+    public void removeFirst_removes_nothing_and_returns_empty_Optional_if_no_elements_match_the_predicate() {
+        final List<Integer> list = listOf(1, 2, 3);
+        assertFalse(removeFirst(list, x -> x < 0).isPresent());
+        assertArrayEquals(new Integer[] {1, 2, 3}, list.toArray());
     }
 
 }


### PR DESCRIPTION
Implemented #1931.
As described, 3 individual validators were implemented to be implicitly applied to String-typed keys and key-members.
The implicit application was implemented by means of merging `@Handler`s into the `@BeforeChange` annotation if a property had already declared it, otherwise `@BeforeChange` is implicitly added with the 3 validators as its handlers.
The `@Handler` merging process is quite simple: handlers are joined into a single array with the implicit ones ordered first. No deduplication takes place, since it is expected that key and key-member properties will not explicitly declare any of the 3 validators (it would not make sense).
Regarding the Java version, only constructs up to Java 8 (1.8) were used.