### PR TITLE
Issue #1997 (modern) - Relax `a` tag restriction in the confirmation dialog messages

### DIFF
--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/reflection/tg-polymer-utils.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/reflection/tg-polymer-utils.js
@@ -271,7 +271,7 @@ export const getKeyEventTarget = function (startFrom, orElse, doDuringSearch) {
  *  
  */
 export const containsRestrictedTags = function (htmlText) {
-    const offensiveTag = new RegExp('<html|<body|<script|<img|<a', 'mi');
+    const offensiveTag = new RegExp('<html|<body|<script|<img', 'mi');
     return offensiveTag.exec(htmlText) !== null;
 }
 


### PR DESCRIPTION
merge from issue #1997