### PR TITLE
A couple of light tweaks to the tg release script:

### DIFF
--- a/tg-release.sh
+++ b/tg-release.sh
@@ -1,29 +1,34 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Ensure all parameters are provided
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <release-version> <next-development-version> <database-uri-prefix> <fork-count>"
+    exit 1
+fi
 
 RELEASE_VERSION=$1
 NEXT_DEVELOPMENT_VERSION=$2
 DATABASE_URI_PREFIX=$3
 FORK_COUNT=$4
 
-# Ensure all parameters are provided
-if [ -z "$RELEASE_VERSION" ] || [ -z "$NEXT_DEVELOPMENT_VERSION" ] || [ -z "$DATABASE_URI_PREFIX" ] || [ -z "$FORK_COUNT" ]; then
-  echo "Usage: $0 <release-version> <next-development-version> <database-uri-prefix> <fork-count>"
-  exit 1
-fi
-
 ###########################
 ###### Definitions ########
 ###########################
-# Define colors
-RED="\033[1;31m"
-GREEN="\033[1;32m"
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-# Define styles
-BOLD='\033[1m'
-UNDERLINE='\033[4m'
-# Reset style
-NORMAL="\033[0m"
+if test -t 1; then
+    ncolours=$(tput colors)
+    if test -n "$ncolours" && test $ncolours -ge 8; then
+        # Define colours
+        RED="$(tput setaf 1)"
+        GREEN="$(tput setaf 2)"
+        YELLOW="$(tput setaf 3)"
+        BLUE="$(tput setaf 4)"
+        # Define styles
+        BOLD="$(tput bold)"
+        UNDERLINE="$(tput smul)"
+        # Reset style
+        NORMAL="$(tput sgr0)"
+    fi
+fi
 
 # Function to report errors
 error() {
@@ -49,7 +54,7 @@ info() {
 abort_release() {
   error "Aborting release process."
   git checkout develop
-  git branch -D release-$RELEASE_VERSION
+  git branch -D release-${RELEASE_VERSION}
   exit 1
 }
 
@@ -61,47 +66,48 @@ info "Fetch latest changes"
 git checkout develop && git pull origin develop || { error "Failed to fetch latest changes"; exit 1; }
 
 info "Start the release branch"
-git checkout -b release-$RELEASE_VERSION || { error "Failed to create release branch"; exit 1; }
+git checkout -b release-${RELEASE_VERSION} || { error "Failed to create release branch"; exit 1; }
 
 info "Update version to release version"
-mvn versions:set -DnewVersion=$RELEASE_VERSION -DprocessAllModules=true -DgenerateBackupPoms=false && \
-mvn versions:commit -DgenerateBackupPoms=false || { error "Failed to update version to release version"; abort_release; }
+mvn versions:set -DnewVersion=${RELEASE_VERSION} -DprocessAllModules=true -DgenerateBackupPoms=false && \
+    mvn versions:commit -DgenerateBackupPoms=false || { error "Failed to update version to release version"; abort_release; }
 
 info "Commit the changes"
-git add pom.xml **/pom.xml && git commit -m "Update versions for release $RELEASE_VERSION" || { error "Failed to commit version changes"; abort_release; }
+git add pom.xml **/pom.xml && git commit -m "Update versions for release ${RELEASE_VERSION}" || { error "Failed to commit version changes"; abort_release; }
 
 info "Merge release branch into master and tag the release"
 git checkout master && git pull origin master && \
-git merge --no-ff release-$RELEASE_VERSION || { error "Failed to merge release branch into master"; abort_release; }
-git tag -a $RELEASE_VERSION -m "Release $RELEASE_VERSION" || { error "Failed to tag the release"; abort_release; }
+    git merge --no-ff release-${RELEASE_VERSION} || { error "Failed to merge release branch into master"; abort_release; }
+git tag -a ${RELEASE_VERSION} -m "Release ${RELEASE_VERSION}" || { error "Failed to tag the release"; abort_release; }
 
 info "Install locally"
-if ! mvn clean install -DdatabaseUri.prefix=$DATABASE_URI_PREFIX -Dfork.count=$FORK_COUNT; then
+if ! mvn clean install -DdatabaseUri.prefix=${DATABASE_URI_PREFIX} -Dfork.count=${FORK_COUNT}; then
   error "Failed to install locally. Please inspect the output for errors."
   abort_release
 fi
 
 info "Deploy the release"
-if ! mvn deploy -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -DdatabaseUri.prefix=$DATABASE_URI_PREFIX -Dfork.count=$FORK_COUNT; then
+if ! mvn deploy -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -DdatabaseUri.prefix=${DATABASE_URI_PREFIX} -Dfork.count=${FORK_COUNT}; then
   error "Failed to deploy. Please inspect the output for errors."
   abort_release
 fi
 
 info "Merge release branch back into develop"
 git checkout develop && git pull origin develop && \
-git merge --no-ff release-$RELEASE_VERSION || { error "Failed to merge release branch back into develop"; abort_release; }
+    git merge --no-ff release-${RELEASE_VERSION} || { error "Failed to merge release branch back into develop"; abort_release; }
 
 info "Update version to next development version"
-mvn versions:set -DnewVersion=$NEXT_DEVELOPMENT_VERSION -DprocessAllModules=true -DgenerateBackupPoms=false && \
-mvn versions:commit -DgenerateBackupPoms=false || { error "Failed to update version to next development version"; abort_release; }
+mvn versions:set -DnewVersion=${NEXT_DEVELOPMENT_VERSION} -DprocessAllModules=true -DgenerateBackupPoms=false && \
+    mvn versions:commit -DgenerateBackupPoms=false || { error "Failed to update version to next development version"; abort_release; }
 
 info "Commit the changes"
-git add pom.xml **/pom.xml && git commit -m "Update versions to $NEXT_DEVELOPMENT_VERSION" || { error "Failed to commit next development version changes"; abort_release; }
+git add pom.xml **/pom.xml && git commit -m "Update versions to ${NEXT_DEVELOPMENT_VERSION}" || { error "Failed to commit next development version changes"; abort_release; }
 
 info "Delete the release branch"
-git branch -d release-$RELEASE_VERSION || { error "Failed to delete the release branch"; exit 1; }
+git branch -d release-${RELEASE_VERSION} || { error "Failed to delete the release branch"; exit 1; }
 
 info "Push changes to remote"
 git push origin develop && git push origin master && git push origin --tags || { error "Failed to push changes to remote"; exit 1; }
 
-success "Successfully released $RELEASE_VERSION"
+success "Successfully released ${RELEASE_VERSION}"
+


### PR DESCRIPTION
  • altered the shebang line to be more portable
  • check for exactly 4 parameters first - this avoids someone accidentally passing one parameter containing a space and forgetting to quote it
  • use `tput` to determine colour escape sequences, which is more portable
  • added braces around all variable names - not strictly necessary in most cases, but a good practice
  • indented lines following a line with `&&` - this makes it easier to see that some lines are appended with `&&`, which makes the following command conditional
  • an interesting mix of `cmd1 || { cmd2; cmd3; }` and `if ! cmd1; then`, although the reasons for choosing one of the other are suspected; choosing one standard would be preferable, but the length of the commands and the mix of `&&` and `||` across multiple related commands makes this challenging