### PR TITLE
Issue #2344 - SequentialGroupingStream should take responsibility for closing the base stream

### DIFF
--- a/platform-dao/src/main/java/ua/com/fielden/platform/dao/CommonEntityDao.java
+++ b/platform-dao/src/main/java/ua/com/fielden/platform/dao/CommonEntityDao.java
@@ -283,7 +283,8 @@ public abstract class CommonEntityDao<T extends AbstractEntity<?>> extends Abstr
     }
 
     /**
-     * Returns a session instances without any checks. It is intended mainly for testing purposes to ensure correct session state after various db operations.
+     * Returns a session instances without any checks.
+     * It is intended mainly for testing purposes to ensure correctness of the session state after various db operations.
      *
      * @return
      */

--- a/platform-dao/src/main/java/ua/com/fielden/platform/entity/query/stream/ScrollableResultStream.java
+++ b/platform-dao/src/main/java/ua/com/fielden/platform/entity/query/stream/ScrollableResultStream.java
@@ -39,15 +39,20 @@ public class ScrollableResultStream {
 
         @Override
         public boolean tryAdvance(Consumer<? super Object[]> action) {
-            final boolean advanced = results.next();
-            
-            if (!advanced) {
-                return false;
-            } else {
-                action.accept(results.get());
+            try {
+                final boolean advanced = results.next();
+
+                if (!advanced) {
+                    return false;
+                } else {
+                    action.accept(results.get());
+                }
+
+                return true;
+            } catch (final Throwable ex) {
+                results.close();
+                throw ex;
             }
-            
-            return true;
         }
 
         @Override
@@ -60,7 +65,7 @@ public class ScrollableResultStream {
         public long estimateSize() {
             // the requirement of this method is to be able to compute the size before stream traversal has started
             // in our case this means that we would need to execute a query to compute the count even before someone tried to access the data
-            // so, for now lets consider the size too expensive to compute by returning Long.MAX_VALUE.
+            // so, for now let's consider the size too expensive to compute by returning Long.MAX_VALUE.
             return Long.MAX_VALUE;
         }
 

--- a/platform-dao/src/main/java/ua/com/fielden/platform/eql/retrieval/EntityContainerFetcher.java
+++ b/platform-dao/src/main/java/ua/com/fielden/platform/eql/retrieval/EntityContainerFetcher.java
@@ -118,8 +118,8 @@ public class EntityContainerFetcher {
 
         final EntityRawResultConverter<E> entityRawResultConverter = new EntityRawResultConverter<>(executionContext.getEntityFactory());
 
-        return SequentialGroupingStream.stream(stream, (el, group) -> group.size() < batchSize, Optional.of(batchSize)) //
-                .map(group -> entityRawResultConverter.transformFromNativeResult(resultTree, group));
+        return SequentialGroupingStream.streamClosedOnTermination(stream, (el, group) -> group.size() < batchSize, Optional.of(batchSize))
+                                       .map(group -> entityRawResultConverter.transformFromNativeResult(resultTree, group));
     }
 
     protected static <E extends AbstractEntity<?>> QueryModelResult<E> getModelResult(final QueryProcessingModel<E, ?> qem, final DbVersion dbVersion, final IFilter filter, final String username, final IDates dates, final EqlDomainMetadata eqlDomainMetadata) {

--- a/platform-dao/src/main/java/ua/com/fielden/platform/ioc/session/SessionInterceptor.java
+++ b/platform-dao/src/main/java/ua/com/fielden/platform/ioc/session/SessionInterceptor.java
@@ -1,12 +1,5 @@
 package ua.com.fielden.platform.ioc.session;
 
-import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
-import static org.apache.logging.log4j.LogManager.getLogger;
-import static ua.com.fielden.platform.dao.annotations.SessionRequired.ERR_NESTED_SCOPE_INVOCATION_IS_DISALLOWED;
-
-import java.util.stream.Stream;
-
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.lang3.StringUtils;
@@ -15,13 +8,19 @@ import org.hibernate.FlushMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-
 import ua.com.fielden.platform.dao.ISessionEnabled;
 import ua.com.fielden.platform.dao.annotations.SessionRequired;
 import ua.com.fielden.platform.error.Result;
 import ua.com.fielden.platform.ioc.session.exceptions.SessionScopingException;
 import ua.com.fielden.platform.ioc.session.exceptions.TransactionRollbackDueToThrowable;
 import ua.com.fielden.platform.security.user.User;
+
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static ua.com.fielden.platform.dao.annotations.SessionRequired.ERR_NESTED_SCOPE_INVOCATION_IS_DISALLOWED;
 
 /**
  * Intercepts methods annotated with {@link SessionRequired} to inject Hibernate session before the actual method execution. Nested invocation of methods annotated with
@@ -63,13 +62,13 @@ public class SessionInterceptor implements MethodInterceptor {
         final User user = invocationOwner.getUser();
 
         try {
-            // This variable indicates whether transaction commit should be handled in this method invocation.
-            // Basically, if transaction is activated in this method then it should be committed only in this method.
-            // Therefore, shouldCommit is assigned true only when transaction is activated here.
+            // This variable indicates whether a transaction commit should be handled in this method invocation.
+            // Basically, if a transaction is activated in this method, then it should be committed only in this method.
+            // Therefore, shouldCommit is assigned true only when the transaction is activated here.
             final boolean shouldCommit = initTransaction(invocationOwner, session, tr, user);
             
-            // if should not commit, which means the session was initiated earlier in the calls stack, 
-            // and support for nested calls is not allowed then an exception should be thrown.
+            // if should not commit, which means the session was initiated earlier in the call stack,
+            // and support for nested calls is not allowed, then an exception should be thrown.
             if (!shouldCommit && !invocation.getStaticPart().getAnnotation(SessionRequired.class).allowNestedScope()) {
                 throw new SessionScopingException(format(ERR_NESTED_SCOPE_INVOCATION_IS_DISALLOWED, invocation.getMethod().getDeclaringClass().getName(), invocation.getMethod().getName()));
             }
@@ -77,13 +76,13 @@ public class SessionInterceptor implements MethodInterceptor {
             // now let's proceed with the actual method invocation, which may throw an exception... or even a throwable...
             final Object result = invocation.proceed();
             
-            // if this is the invocation that activated the current transaction then we should commit it
-            // but only of the result of invocation is not a stream -- in that case closing of the session is the responsibility of that stream
+            // if this is the invocation that activated the current transaction, then we should commit it,
+            // but only if the result of invocation is not a stream -- in that case, closing of the session is the responsibility of that stream
             if (shouldCommit && tr.isActive()) {
-                // if the result is a stream than the current transaction becomes associated with that stream
+                // if the result is a stream, then the current transaction becomes associated with that stream
                 // and needs to be committed once the stream has been processed
-                if (result instanceof Stream) {
-                    ((Stream<?>) result).onClose(() -> {
+                if (result instanceof Stream stream) {
+                    return stream.onClose(() -> {
                         try {
                             LOGGER.debug(format("[%s] Committing DB transaction on stream close.", user));
                             commitTransactionAndCloseSession(session, tr, user);
@@ -93,15 +92,19 @@ public class SessionInterceptor implements MethodInterceptor {
                             throw ex;
                         }
                     });
-                } else { // otherwise, commit the current transaction
+                }
+                // otherwise, commit the current transaction
+                else {
                     LOGGER.debug(format("[%s] Committing DB transaction", user));
                     commitTransactionAndCloseSession(session, tr, user);
                     LOGGER.debug(format("[%s] Committed DB transaction", user));
+                    return result;
                 }
-            } else if (session.isOpen()) {
-                // this is the case of a nested transaction
-                // should flush only if the current session is still open
-                // this check was not needed before migrating off Hibernate 3.2.6 GA
+            }
+            // otherwise, this is the case of a nested transaction
+            // should flush only if the current session is still open
+            // this check was not needed before migrating off Hibernate 3.2.6 GA
+            if (session.isOpen()) {
                 session.flush();
             }
             return result;

--- a/platform-dao/src/test/java/ua/com/fielden/platform/dao/CommonEntityDaoStreamingTestCase.java
+++ b/platform-dao/src/test/java/ua/com/fielden/platform/dao/CommonEntityDaoStreamingTestCase.java
@@ -1,23 +1,6 @@
 package ua.com.fielden.platform.dao;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static ua.com.fielden.platform.entity.query.fluent.EntityQueryUtils.from;
-import static ua.com.fielden.platform.entity.query.fluent.EntityQueryUtils.orderBy;
-import static ua.com.fielden.platform.entity.query.fluent.EntityQueryUtils.select;
-import static ua.com.fielden.platform.types.try_wrapper.TryWrapper.Try;
-
-import java.math.BigDecimal;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.junit.Test;
-
 import ua.com.fielden.platform.dao.annotations.SessionRequired;
 import ua.com.fielden.platform.entity.query.EntityAggregates;
 import ua.com.fielden.platform.entity.query.model.AggregatedResultQueryModel;
@@ -29,8 +12,19 @@ import ua.com.fielden.platform.test.ioc.UniversalConstantsForTesting;
 import ua.com.fielden.platform.test_config.AbstractDaoTestCase;
 import ua.com.fielden.platform.types.Money;
 import ua.com.fielden.platform.types.either.Either;
-import ua.com.fielden.platform.types.either.Left;
 import ua.com.fielden.platform.utils.IUniversalConstants;
+
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.*;
+import static ua.com.fielden.platform.entity.query.fluent.EntityQueryUtils.*;
+import static ua.com.fielden.platform.types.try_wrapper.TryWrapper.Try;
 
 /**
  * This test case ensures correct implementation of the db-driven companion streaming functionality.
@@ -66,7 +60,7 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
 
     @Test
     @SessionRequired
-    public void streaming_based_on_ordered_qem_should_have_the_same_traversal_order() {
+    public void streaming_based_on_ordered_qem_has_the_intended_order_of_elements() {
         final EntityResultQueryModel<EntityWithMoney> query = select(EntityWithMoney.class).model();
         final OrderingModel orderBy = orderBy().prop("key").asc().model();
         final QueryExecutionModel<EntityWithMoney, EntityResultQueryModel<EntityWithMoney>> qem = from(query).with(orderBy).model();
@@ -79,7 +73,7 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
 
     @Test
     @SessionRequired
-    public void streaming_based_on_conditional_qem_should_contain_only_matching_entities() {
+    public void streaming_based_on_conditional_qem_contain_only_matching_entities() {
         final EntityResultQueryModel<EntityWithMoney> query = select(EntityWithMoney.class)
                 .where().prop("money.amount").ge().val(new BigDecimal("30.00"))//
                 .model();
@@ -92,7 +86,7 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
 
     @Test
     @SessionRequired
-    public void stream_should_not_be_parallel() {
+    public void stream_is_not_parallel() {
         try (final Stream<EntityWithMoney> streamBy3 = co$(EntityWithMoney.class).stream(from(select(EntityWithMoney.class).model()).model(), 2)) {
             assertFalse("The stream should not be parallel", streamBy3.isParallel());
         }
@@ -100,24 +94,27 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
 
     @Test
     @SessionRequired
-    public void stream_should_not_be_accecible_once_traversed() {
+    public void stream_cannot_be_processed_again_after_a_terminal_operation() {
         final Either<Exception, Long> result = Try(() -> {
             try (final Stream<EntityWithMoney> stream = co$(EntityWithMoney.class).stream(from(select(EntityWithMoney.class).model()).model(), 2)) {
-                // consume the stream by traversing it
-                stream.forEach(e -> e.getMoney()/* basically do nothing*/);
-                // try to consume the stream again by counting the number of elements in it
+                // the first terminal operation
+                stream.forEach(e -> e.getMoney());
+                // try to run another terminal operation, which should throw
                 return stream.count();
             }});
         
-        assertTrue(result instanceof Left);
-        assertEquals("stream has already been operated upon or closed", ((Left<Exception, Long>) result).value.getMessage());
+        assertTrue(result.isLeft());
+        assertTrue(result.asLeft().value instanceof IllegalStateException);
+        assertEquals("stream has already been operated upon or closed", result.asLeft().value.getMessage());
     }
 
     @Test
-    public void streams_that_are_used_outside_an_existing_db_session_are_responsible_for_its_closing() {
+    public void streams_created_outside_of_existing_db_session_are_responsible_for_opening_and_closing_their_own_session() {
         final EntityWithMoneyDao co = co$(EntityWithMoney.class);
+        assertNull("No session is expected.", co.getSessionUnsafe());
         try (final Stream<EntityWithMoney> stream = co.stream(from(select(EntityWithMoney.class).model()).model())) {
-            assertTrue("Session should still be open.", co.getSessionUnsafe().isOpen());
+            assertNotNull("A new session is expected.", co.getSessionUnsafe());
+            assertTrue("Session should be open.", co.getSessionUnsafe().isOpen());
         }
         assertFalse("Session should already be closed", co.getSessionUnsafe().isOpen());
     }
@@ -136,7 +133,7 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
     }
 
     @Test
-    public void counting_data_in_stream_does_not_close_it() {
+    public void terminal_op_on_data_stream_with_its_own_session_performed_outside_try_with_resources_does_not_close_that_session() {
         final EntityWithMoneyDao co = co$(EntityWithMoney.class);
         final Stream<EntityWithMoney> dataStream = co.stream(from(select(EntityWithMoney.class).model()).model());
         
@@ -150,7 +147,7 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
     }
 
     @Test
-    public void collecting_data_from_stream_does_not_close_it() {
+    public void terminal_op_on_data_stream_with_its_own_session_performed_inside_try_with_resources_does_not_close_that_session() {
         final EntityWithMoneyDao co = co$(EntityWithMoney.class);
         
         final Map<Boolean, List<EntityWithMoney>> partition;
@@ -158,25 +155,31 @@ public class CommonEntityDaoStreamingTestCase extends AbstractDaoTestCase {
             partition = dataStream.collect(Collectors.partitioningBy(e -> e.getMoney().getAmount().doubleValue() >= 30));
             assertTrue("Session should still be open.", co.getSessionUnsafe().isOpen());
         }
-        
+        assertFalse("Session should already be closed", co.getSessionUnsafe().isOpen());
+
         assertEquals(2, partition.size());
         assertEquals(3, partition.get(true).size());
         assertEquals(1, partition.get(false).size());
-        
-        assertFalse("Session should already be closed", co.getSessionUnsafe().isOpen());
     }
 
     @Test
-    public void streams_that_are_used_within_an_existing_db_session_should_not_close_it() {
+    @SessionRequired
+    public void streams_that_are_used_within_an_existing_db_session_should_not_close_that_session() {
+        assertTrue("The test should start with an open session.", getSession().isOpen());
+
         final EntityResultQueryModel<EntityWithMoney> query = select(EntityWithMoney.class).model();
         final EntityWithMoneyDao co = co$(EntityWithMoney.class);
         
-        // the following method uses a stream and make additional query after closing the stream
-        // if the stream does not close the current session then that query should succeed
-        final long result = co.streamProcessingWithinTransaction(query);
-        
+        // The following code uses a stream in try-with-resources and makes an additional query after the stream is closed, expecting that the current session remains open.
+        long result = 0;
+        try(final var stream = co.stream(from(query).model())) {
+            assertEquals("Stream should happen in the same session as the test itself.", getSession(), co.getSessionUnsafe());
+            result = result + stream.count();
+        }
+        assertTrue("Session should still be open.", co.getSessionUnsafe().isOpen());
+        result = result + co.count(query); // query in still in the scope of the same session
+
         assertEquals(co$(EntityWithMoney.class).count(query) * 2, result);
-        assertFalse("Session should already be closed", co.getSessionUnsafe().isOpen());
     }
 
     @Test

--- a/platform-dao/src/test/java/ua/com/fielden/platform/dao/EntityWithMoneyDao.java
+++ b/platform-dao/src/test/java/ua/com/fielden/platform/dao/EntityWithMoneyDao.java
@@ -51,16 +51,6 @@ public class EntityWithMoneyDao extends CommonEntityDao<EntityWithMoney> impleme
         return new Pair<Session, Session>(ses, getSessionUnsafe());
     }
     
-    @SessionRequired
-    public long streamProcessingWithinTransaction(final EntityResultQueryModel<EntityWithMoney> query) {
-        long result = 0;
-        try(final Stream<EntityWithMoney> stream = stream(from(query).model())) {
-            result = result + stream.count();
-        }
-        result = result + count(query);
-        return result;
-    }
-
     // @SessionRequired -- deliberately not annotated
     public EntityWithMoney superSave(final EntityWithMoney entity) {
         return super.save(entity);

--- a/platform-pojo-bl/src/main/java/ua/com/fielden/platform/streaming/SequentialGroupingStream.java
+++ b/platform-pojo-bl/src/main/java/ua/com/fielden/platform/streaming/SequentialGroupingStream.java
@@ -43,7 +43,7 @@ public class SequentialGroupingStream {
     }
 
     /**
-     * The same as {@link #stream(Stream, BiPredicate, Optional)}, but automatic closing of the base stream upon processing of its last element by a terminal operation, invoked on the resultant stream.
+     * The same as {@link #stream(Stream, BiPredicate, Optional)}, but with automatic closing of the base stream upon processing of its last element by a terminal operation, invoked on the resultant stream.
      * Closing of the resultant stream still leads to closing of the base stream if it was not closed sooner due to the consumption by a terminal operation.
      * <p>
      * For example, if {@link Stream#forEach(Consumer)} or {@link Stream#collect(Collector)} is invoked on the resultant stream, the based stream will get closed after the processing of its last element.


### PR DESCRIPTION
Resolve #2344 

There are significant changes in this PR:

- [x] 1. Changed the behaviour of the stream, produced by `SequentialGroupingStream.stream` by ensuring closing this stream also closes the base stream.
- [x] 2. Introduced alternative factory-method `SequentialGroupingStream.streamClosedOnTermination` that was used in `EntityContainerFetcher` instead of `SequentialGroupingStream.stream` to harden resource management for database based streaming.
- [x] 3. Refactored `SessionInterceptor` to return the result of `stream.onClose` instead of `stream`.