### PR TITLE
#2467 - Entity Centre: saving configuration without any change leads to runtime error

### DIFF
--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/centre/tg-entity-centre.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/centre/tg-entity-centre.js
@@ -564,7 +564,7 @@ Polymer({
                         //   This is possible if validation was triggered fast (in 50 millis debouncing time) since last validation and after current saving process.
                         //   This is very artificial case, because saving will likely be last in the chain of user actions.
                         const lastValidationAttemptPromise = self.lastValidationAttemptPromise();
-                        if (lastValidationAttemptPromise !== null) {
+                        if (lastValidationAttemptPromise) {
                             console.warn("Saving is chained to the last validation attempt promise...", lastValidationAttemptPromise);
                             // Don't reject on rejected 'lastValidationAttemptPromise'.
                             // We should allow SAVE even after validation with connection lost / server (or other) error.


### PR DESCRIPTION
Resolve #2432.

The promise may be undefined and, previously, before #2432, it was not a problem. Now we catch promise rejections, so we need to fix old problematic 'lastValidationAttemptPromise !== null' condition.

# To be completed by the pull request creator

- [x] Create the pull request as a draft by tapping the dropdown arrow on the 'Create pull request' button under the pull request description (below the text box where this description is being edited) and changing the default `Create pull request` to `Draft pull request`.
      Or, if the pull request has already been created, convert it to draft by tapping the "Convert to draft" link beneath the "Reviewers" section.

- [x] A self-review of all changes has been completed, and the changes are in sync with the issue requirements.

- [x] Changes to the requirements have been reflected in the issue description.

- [x] Any "leftovers" such as sysouts, printing of stack traces, and any other "temporary" code, have been removed.

- [x] All existing and new Java tests pass successfully by running them with Maven.

- [x] All existing and new Web tests pass successfully.

- [x] Changes have been inspected for possible NPE situations, and the changes are sufficiently defensive.

- [x] The correct base branch has been selected for these changes to be merged into.

- [x] The latest changes from the base branch have already been merged into this feature branch (and tested).

- [x] This pull request does not contain significant changes, and at least one appropriate reviewer has been selected.

- [x] The `In progress` label has been removed from the issue.

- [x] The `Pull request` label has been added to the issue.

- [x] The pull request has been made ready for review by tapping the "Ready for review" button below the list of commits on the pull request page.

# To be completed by the pull request reviewer

This section should be completed with reference to section [Performing PR review](https://github.com/fieldenms/devops/wiki/Code-and-PR-reviews#performing-pr-review) of the [Code and PR reviews](https://github.com/fieldenms/devops/wiki/Code-and-PR-reviews) wiki page.

<!-- Delete any items that are not applicable. -->

- [x] The `In progress` label has been added to the pull request in GitHub.

- [x] The issue requirements have been read and understood (along with any relevant emails and/or Slack messages).

- [x] The correct base branch is specified, and that base branch is up-to-date in the local source.

- [x] The issue branch has been checked out locally, and had the base branch merged into it.

- [x] All automated tests pass successfully.

- [x] Ensure the implementation satisfies the functional requirements.

- [x] Ensure that code changes are secure and align with the established coding practices, including code formatting and naming conventions.

- [x] Ensure that code changes are documented and covered with automated tests as applicable.

- [x] Ensure that code changes are well-suited for informal reasoning.

- [x] Ensure that changes are documented for the end-user (a software engineer in the case of TG, or an application user in the case of TG-based applications).

- [x] If there are significant changes (described above), special attention has been paid to them.
      Marked the task items in section "Significant changes" as completed to indicate that corresponding changes have been reviewed, improved if necessary, and approved.

- [x] The issue or issues addressed by the pull request are associated with the relevant release milestone.

# To be completed by the pull request reviewer once the changes have been reviewed and accepted

- [x] The changes have been merged into the base branch (unless there is a specific request not to do so, e.g., they are to be released to SIT).

- [x] The issue branch has been deleted (unless the changes have not been merged - see above, or there is a specific request not to do so).

- [x] The `In progress` label has been removed from the pull request.

- [x] The `Pull request` label has been removed from the issue.

