### PR TITLE
Issue #2819 - Customise Columns: column reordering unreliable on touch devices

### DIFF
--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/components/tg-global-error-handler.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/components/tg-global-error-handler.js
@@ -91,7 +91,7 @@ class TgGlobalErrorHandler extends PolymerElement {
             /**
              * @property {Array}
              * Queue of errors to be sent to the server for processing.
-             * /
+             */
             _errorQueue: Array,
 
             /**

--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
@@ -22,6 +22,8 @@ import { UnreportableError } from '/resources/components/tg-global-error-handler
  * The classic user-agent string is frozen by the browser, so on Android it always reports version `10` and model `K`.
  * Only User-Agent Client Hints can identify the actual OS version, device model and rendering engine.
  * This is a constant for the lifetime of the page, so it is resolved once and cached.
+ * The reported value is a device description, or `uach=unavailable` on engines without Client Hints, as confirmed on iOS Safari 26.6.
+ * It is `uach=error` if the query is rejected, and `uach=pending` if a session is reported before the query settles.
  */
 let _uaDetails = null;
 
@@ -73,7 +75,9 @@ const additionalTemplate = html`
             @apply --layout-center;
             padding: 16px 16px 16px 0;
             border-bottom: 1px solid #DDD;
-            /* Long-pressing selectable text competes with drag initiation on touch devices. */
+        }
+        /* Long-pressing selectable text competes with drag initiation on touch devices; only reorderable lists are dragged. */
+        :host([can-reorder-items]) .item {
             -webkit-user-select: none;
             -moz-user-select: none;
             -ms-user-select: none;
@@ -394,12 +398,16 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
         this.addEventListener('dragend', this._endDrag.bind(this));
 
         // Diagnostic listeners for issue #2819; these only count events and never interfere with them.
-        this.addEventListener('pointerdown', this._dndPointerDown.bind(this));
-        this.addEventListener('pointermove', this._dndPointerMove.bind(this));
-        this.addEventListener('pointerup', this._dndPointerEnd.bind(this));
-        this.addEventListener('pointercancel', this._dndPointerEnd.bind(this));
-        this.addEventListener('contextmenu', () => this._countDnd("ctx"));
-        this.addEventListener('selectstart', () => this._countDnd("sel"));
+        // Only reorderable lists are reported, so there is nothing to observe on the rest.
+        if (this.canReorderItems) {
+            this.addEventListener('pointerdown', this._dndPointerDown.bind(this));
+            this.addEventListener('pointermove', this._dndPointerMove.bind(this));
+            this.addEventListener('pointerup', this._dndPointerEnd.bind(this));
+            this.addEventListener('pointercancel', this._dndPointerEnd.bind(this));
+            this.addEventListener('contextmenu', e => this._dndRowFor(e) && this._countDnd("ctx"));
+            // `selectstart` is not composed, so it never leaves this shadow root and has to be observed there rather than on the host.
+            this.shadowRoot.addEventListener('selectstart', e => this._dndRowFor(e) && this._countDnd("sel"));
+        }
 
         this._touchEnabled = isTouchEnabled();
     }
@@ -410,7 +418,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
         this._reportDndDiag();
         this._originalChosenIds = null;
         this._phraseForSearching ="";
-        this._dndDiag = {taps: 0, held: 0, ctx: 0, sel: 0, pcancel: 0, dragstart: 0, dragInit: 0, dropped: 0};
+        this._dndDiag = {taps: 0, held: 0, ctx: 0, sel: 0, pcancel: 0, dragstart: 0, dragInit: 0, dropped: 0, dragend: 0};
         _resolveUaDetails();
     }
 
@@ -985,6 +993,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
     }
 
     _endDrag (dragEvent) {
+        this._countDnd("dragend");
         if (this._reorderingObject) {
             this.moveItem(this._reorderingObject.from, this._reorderingObject.origin);
             delete this._reorderingObject;
@@ -994,13 +1003,15 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
     
     /**
      * Returns the reorderable row that the specified event originated from, or `null`.
+     * The target of `selectstart` is a text node, so it is normalised to the closest element before walking up.
      */
     _dndRowFor (e) {
         const target = e.composedPath()[0];
-        if (!target || target.nodeType !== Node.ELEMENT_NODE) {
+        const startElement = target && (target.nodeType === Node.ELEMENT_NODE ? target : target.parentElement);
+        if (!startElement) {
             return null;
         }
-        return getParentAnd(target, element => element.hasAttribute("drag-element"));
+        return getParentAnd(startElement, element => element.hasAttribute("drag-element")) || null;
     }
 
     /**
@@ -1068,7 +1079,11 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
      * A non-zero `sel` means that suppression of text selection is not in effect on the device.
      * `pcancel` counts cancellation of the pointer stream, which is expected once per drag but, alongside `dragstart` of `0`, indicates that something outside the page is taking the touch.
      * A non-zero `dragstart` with `dragInit` of `0` means the drag was initiated but the row was not recognised as draggable.
-     * A non-zero `dragInit` with `dropped` of `0` means the drop was never registered, which also happens when the user returns an item to its original position.
+     * A non-zero `dragInit` with `dropped` of `0` means that no drop was delivered.
+     * `_dragOver` marks the editor as a valid drop target, so a drop anywhere over it is counted, including one back at the starting position.
+     * What remains is an abandoned drag, such as a release outside the editor, and an engine that never delivers a drop at all, as observed on iOS Safari.
+     * `dragend` counts the engine signalling the end of a drag, which separates those two cases.
+     * Alongside `dropped` of `0`, a non-zero `dragend` means the drag was abandoned, while `dragend` of `0` means the engine never ended it.
      * Reporting is done with `UnreportableError`, which reaches the server log via `/error` without a toast for the user.
      * Only lists with reordering enabled are reported, which confines this to `Customise Columns` and keeps the volume to one line per dialog session.
      * Nothing is used as a filter beyond that, so that an absent breadcrumb means a broken breadcrumb.
@@ -1082,7 +1097,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
         this._dndDiag = null;
         Promise.reject(new UnreportableError(
             `DND-DIAG touch=${this._touchEnabled} taps=${diag.taps} held=${diag.held} ctx=${diag.ctx} sel=${diag.sel}` +
-            ` pcancel=${diag.pcancel} dragstart=${diag.dragstart} dragInit=${diag.dragInit} dropped=${diag.dropped}` +
+            ` pcancel=${diag.pcancel} dragstart=${diag.dragstart} dragInit=${diag.dragInit} dropped=${diag.dropped} dragend=${diag.dragend}` +
             ` mtp=${navigator.maxTouchPoints} vw=${window.innerWidth} ${_uaDetails} ua=${navigator.userAgent}`));
     }
 

--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
@@ -682,7 +682,12 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
     }
 
     _computeStyleForDragAnchor (selected, _touchEnabled) {
-        return !selected || _touchEnabled ? "visibility: hidden;" : ""; 
+        if (!selected) {
+            return "visibility: hidden;";
+        }
+        // A touch device has no hover, so the handle of a selected row has to be shown outright rather than left to `.item:hover .drag-anchor`.
+        // It serves only as an affordance there, because on touch it is the row that carries `draggable` rather than the handle.
+        return _touchEnabled ? "visibility: visible;" : "";
     }
 
     _computeTitleStyle (canReorderItems) {
@@ -952,7 +957,8 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
                 this._countDnd("dragInit");
                 const relMousePos = getRelativePos(dragEvent.clientX, dragEvent.clientY, elementToDrag);
                 dragEvent.dataTransfer.effectAllowed = "copyMove";
-                dragEvent.dataTransfer.setDragImage(this._createDragImage(elementToDrag), relMousePos.x, relMousePos.y);
+                const dragImage = this._createDragImage(elementToDrag, relMousePos);
+                dragEvent.dataTransfer.setDragImage(dragImage.element, dragImage.x, dragImage.y);
                 hideTooltip();
                 // Assignment of the dragging state is deferred, because it hides the row through `[is-dragging-item]`
                 // and, on a desktop, the drag handle that carries `draggable` through `drag-mode` on `iron-list`.
@@ -1025,35 +1031,57 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
     }
 
     /**
-     * Creates an untransformed copy of the specified row to serve as the drag image.
+     * Creates the drag image for the specified row, as an untransformed copy of it placed inside a transparent container.
      * `iron-list` positions every row with an inline `transform: translate3d(0, Ypx, 0)`, so only the first row of an unscrolled list has `Y` of `0`.
      * WebKit appears to disregard that transform when it rasterises a drag image, painting the row outside the bounds of the resulting bitmap.
      * The drag then has no visual representation for every row except the one at `Y` of `0`, as observed on macOS Safari 26.5 for issue #2819.
-     * Clearing `transform` on the copy removes that offset, which is the whole point of taking a copy.
-     * The copy is appended to this shadow root so that the same scoped rules style it as a row, and it is positioned off-screen so that it can be neither seen nor interacted with.
+     * Clearing `transform` on the copy removes that offset.
+     * The container is padded on touch, because a touch device centres the drag image on the touch point rather than honour the hot spot given to `setDragImage`.
+     * Sizing it so that the grab point falls at its centre makes the hot spot and the centre one and the same coordinate, which positions the row correctly either way.
+     * Padding costs up to twice the size of a row, so it is confined to touch, where a hot spot would otherwise be ignored.
+     * A wide row would otherwise exceed the largest drag image an engine will render, which Chrome truncates rather than scales, as seen on a maximised window holding a maximised dialog.
+     * The container is appended to this shadow root so that the same scoped rules style the copy as a row, and it is positioned off-screen so that it can be neither seen nor interacted with.
+     * The returned hot spot follows the copy, so that it is the grab point wherever within the container the copy has been placed.
      */
-    _createDragImage (elementToDrag) {
+    _createDragImage (elementToDrag, grabPos) {
         this._removeDragImage();
         const rect = elementToDrag.getBoundingClientRect();
-        const dragImage = elementToDrag.cloneNode(true);
+        const row = elementToDrag.cloneNode(true);
         // The copy must not be mistaken for a row by the drag handlers or by the diagnostics.
-        dragImage.removeAttribute("drag-element");
-        dragImage.removeAttribute("collectional-index");
-        dragImage.removeAttribute("draggable");
+        row.removeAttribute("drag-element");
+        row.removeAttribute("collectional-index");
+        row.removeAttribute("draggable");
         // `cloneNode` copies the `style` attribute, so the inline transform of the row has to be cleared explicitly.
-        dragImage.style.transform = "none";
+        row.style.transform = "none";
+        row.style.position = "absolute";
+        row.style.width = `${rect.width}px`;
+        row.style.height = `${rect.height}px`;
+
+        // Padding the container out to twice the larger distance from the grab point to an edge leaves that point at the centre, with the row still wholly inside.
+        const padded = this._touchEnabled;
+        const width = padded ? 2 * Math.max(grabPos.x, rect.width - grabPos.x) : rect.width;
+        const height = padded ? 2 * Math.max(grabPos.y, rect.height - grabPos.y) : rect.height;
+        const left = padded ? width / 2 - grabPos.x : 0;
+        const top = padded ? height / 2 - grabPos.y : 0;
+        row.style.left = `${left}px`;
+        row.style.top = `${top}px`;
+
+        const dragImage = document.createElement("div");
         dragImage.style.position = "fixed";
         dragImage.style.top = "0";
         dragImage.style.left = "-100000px";
-        dragImage.style.width = `${rect.width}px`;
-        dragImage.style.height = `${rect.height}px`;
+        dragImage.style.width = `${width}px`;
+        dragImage.style.height = `${height}px`;
+        dragImage.style.background = "transparent";
         dragImage.style.pointerEvents = "none";
         dragImage.style.setProperty("--paper-checkbox-animation-duration", "0s");
+        dragImage.appendChild(row);
+
         this.shadowRoot.appendChild(dragImage);
         this._settleDragImageCheckboxes(dragImage);
         dragImage.offsetHeight; // forces layout, so that an engine rasterising synchronously within `setDragImage` finds the copy laid out
         this._dragImage = dragImage;
-        return dragImage;
+        return {element: dragImage, x: left + grabPos.x, y: top + grabPos.y};
     }
 
     /**

--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
@@ -15,6 +15,34 @@ import { TgEditor, createEditorTemplate } from '/resources/editors/tg-editor.js'
 import { GestureEventListeners } from '/resources/polymer/@polymer/polymer/lib/mixins/gesture-event-listeners.js';
 import { scrollContainerIfPointNearTheEdge, tearDownEvent, isTouchEnabled, getParentAnd, getRelativePos} from '/resources/reflection/tg-polymer-utils.js';
 import { hideTooltip } from '/resources/components/tg-tooltip-behavior.js';
+import { UnreportableError } from '/resources/components/tg-global-error-handler.js';
+
+/**
+ * High-entropy user-agent details for the drag-and-drop diagnostics of issue #2819.
+ * The classic user-agent string is frozen by the browser, so on Android it always reports version `10` and model `K`.
+ * Only User-Agent Client Hints can identify the actual OS version, device model and rendering engine.
+ * This is a constant for the lifetime of the page, so it is resolved once and cached.
+ */
+let _uaDetails = null;
+
+const _resolveUaDetails = function () {
+    if (_uaDetails !== null) {
+        return;
+    }
+    _uaDetails = "uach=pending";
+    const uaData = navigator.userAgentData;
+    if (uaData && uaData.getHighEntropyValues) {
+        uaData.getHighEntropyValues(["platformVersion", "model", "fullVersionList"]).then(values => {
+            const brands = (values.fullVersionList || []).map(brand => `${brand.brand}/${brand.version}`).join(",");
+            _uaDetails = `plat=${uaData.platform}/${values.platformVersion || "?"} model=${values.model || "?"}` +
+                ` uaMobile=${uaData.mobile} brands=[${brands}]`;
+        }).catch(() => {
+            _uaDetails = "uach=error";
+        });
+    } else {
+        _uaDetails = "uach=unavailable";
+    }
+};
 
 const additionalTemplate = html`
     <style>
@@ -365,13 +393,31 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
         this.addEventListener("drop", this._dragDrop);
         this.addEventListener('dragend', this._endDrag.bind(this));
 
+        // Diagnostic listeners for issue #2819; these only count events and never interfere with them.
+        this.addEventListener('pointerdown', this._dndPointerDown.bind(this));
+        this.addEventListener('pointermove', this._dndPointerMove.bind(this));
+        this.addEventListener('pointerup', this._dndPointerEnd.bind(this));
+        this.addEventListener('pointercancel', this._dndPointerEnd.bind(this));
+        this.addEventListener('contextmenu', () => this._countDnd("ctx"));
+        this.addEventListener('selectstart', () => this._countDnd("sel"));
+
         this._touchEnabled = isTouchEnabled();
     }
 
     connectedCallback () {
         super.connectedCallback();
+        // Report the previous session in case it was not reported on disconnection.
+        this._reportDndDiag();
         this._originalChosenIds = null;
         this._phraseForSearching ="";
+        this._dndDiag = {taps: 0, held: 0, ctx: 0, sel: 0, pcancel: 0, dragstart: 0, dragInit: 0, dropped: 0};
+        _resolveUaDetails();
+    }
+
+    disconnectedCallback () {
+        this._dndCancelHoldTimer();
+        this._reportDndDiag();
+        super.disconnectedCallback();
     }
 
     _calcItemTooltip (item) {
@@ -450,6 +496,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
 
     _selectionHandler (e) {
         if (this._isSelectionEnabled(this._forReview)) {
+            this._countDnd("taps");
             this.$.input.toggleSelectionForItem(e.model.item);
             tearDownEvent(e);
         }
@@ -888,10 +935,12 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
     }
 
     _startDrag (dragEvent) {
+        this._countDnd("dragstart");
         const target = dragEvent.composedPath()[0];
         if (target.nodeType === Node.ELEMENT_NODE && target.getAttribute("draggable") === 'true') {
             const elementToDrag = getParentAnd(target, element => element.hasAttribute("drag-element"));
             if (elementToDrag && elementToDrag.hasAttribute("selected")) {
+                this._countDnd("dragInit");
                 const relMousePos = getRelativePos(dragEvent.clientX, dragEvent.clientY, elementToDrag);
                 dragEvent.dataTransfer.effectAllowed = "copyMove";
                 dragEvent.dataTransfer.setDragImage(elementToDrag, relMousePos.x, relMousePos.y); 
@@ -925,6 +974,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
 
     _dragDrop (dragEvent) {
         if (this._reorderingObject) {
+            this._countDnd("dropped");
             const chosenIds = this.entity.get("chosenIds");
             this.entity.setAndRegisterPropertyTouch("chosenIds", this._entities.filter(entity => chosenIds.indexOf(this.idOrKey(entity)) >= 0).map(entity => this.idOrKey(entity)));
             delete this._reorderingObject;
@@ -942,6 +992,100 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
         }
     }
     
+    /**
+     * Returns the reorderable row that the specified event originated from, or `null`.
+     */
+    _dndRowFor (e) {
+        const target = e.composedPath()[0];
+        if (!target || target.nodeType !== Node.ELEMENT_NODE) {
+            return null;
+        }
+        return getParentAnd(target, element => element.hasAttribute("drag-element"));
+    }
+
+    /**
+     * Starts a timer that counts a long press that neither became a drag nor ended within the threshold.
+     * A successful drag cancels the pointer stream well before the threshold, so `held` approximates long presses where nothing happened.
+     */
+    _dndPointerDown (e) {
+        this._dndCancelHoldTimer();
+        if (!this._dndDiag || !this._dndRowFor(e)) {
+            return;
+        }
+        this._dndHoldOrigin = {x: e.clientX, y: e.clientY};
+        this._dndHoldTimer = setTimeout(() => {
+            this._dndHoldTimer = null;
+            this._countDnd("held");
+        }, 600);
+    }
+
+    _dndPointerMove (e) {
+        if (this._dndHoldTimer && this._dndHoldOrigin) {
+            const dx = e.clientX - this._dndHoldOrigin.x;
+            const dy = e.clientY - this._dndHoldOrigin.y;
+            if (dx * dx + dy * dy > 100) { // a movement of more than 10px is not a long press
+                this._dndCancelHoldTimer();
+            }
+        }
+    }
+
+    _dndPointerEnd (e) {
+        if (e.type === "pointercancel") {
+            this._countDnd("pcancel");
+        }
+        this._dndCancelHoldTimer();
+    }
+
+    _dndCancelHoldTimer () {
+        if (this._dndHoldTimer) {
+            clearTimeout(this._dndHoldTimer);
+            this._dndHoldTimer = null;
+        }
+        this._dndHoldOrigin = null;
+    }
+
+    /**
+     * Increments a counter of the current drag-and-drop diagnostic session.
+     * See `_reportDndDiag` for the purpose of this instrumentation.
+     */
+    _countDnd (key) {
+        if (this._dndDiag) {
+            this._dndDiag[key] += 1;
+        }
+    }
+
+    /**
+     * Reports a single diagnostic breadcrumb per session with a reorderable list.
+     * This is temporary instrumentation for issue #2819, where column reordering is reported as not working on managed Android tablets.
+     * Reordering relies on the browser's own long-tap-to-drag gesture on touch devices, so there is otherwise no way to tell whether it fires at all in the field.
+     * A completed reorder on touch reads `held=0 sel=0 pcancel=1 dragstart=1 dragInit=1 dropped=1`.
+     * That reference signature was observed on a Samsung SM-T570 running Android 13 and on a Pixel 8 running Android 17, both with Chrome 151.
+     * `ctx` was `1` on the former and `0` on the latter, so a context menu accompanies a successful drag on some devices but not others.
+     * The remaining counters discriminate between the ways it can fail.
+     * `held` counts long presses that produced no drag, which separates a refused gesture from a user who never attempted one.
+     * `ctx` and `sel` count context menus and text selections on rows.
+     * A context menu is also raised during a successful long-tap drag, so `ctx` indicates pre-emption of the drag only when `dragstart` is `0`.
+     * A non-zero `sel` means that suppression of text selection is not in effect on the device.
+     * `pcancel` counts cancellation of the pointer stream, which is expected once per drag but, alongside `dragstart` of `0`, indicates that something outside the page is taking the touch.
+     * A non-zero `dragstart` with `dragInit` of `0` means the drag was initiated but the row was not recognised as draggable.
+     * A non-zero `dragInit` with `dropped` of `0` means the drop was never registered, which also happens when the user returns an item to its original position.
+     * Reporting is done with `UnreportableError`, which reaches the server log via `/error` without a toast for the user.
+     * Only lists with reordering enabled are reported, which confines this to `Customise Columns` and keeps the volume to one line per dialog session.
+     * Nothing is used as a filter beyond that, so that an absent breadcrumb means a broken breadcrumb.
+     * The device kind stamped by `WebClientErrorLoggerResource` has been observed to be inaccurate, so device details travel in the payload.
+     */
+    _reportDndDiag () {
+        const diag = this._dndDiag;
+        if (!diag || !this.canReorderItems) {
+            return;
+        }
+        this._dndDiag = null;
+        Promise.reject(new UnreportableError(
+            `DND-DIAG touch=${this._touchEnabled} taps=${diag.taps} held=${diag.held} ctx=${diag.ctx} sel=${diag.sel}` +
+            ` pcancel=${diag.pcancel} dragstart=${diag.dragstart} dragInit=${diag.dragInit} dropped=${diag.dropped}` +
+            ` mtp=${navigator.maxTouchPoints} vw=${window.innerWidth} ${_uaDetails} ua=${navigator.userAgent}`));
+    }
+
     _getIndexForElement (element) {
         let currentElement = element;
         while (currentElement && !currentElement.hasAttribute("collectional-index")) {

--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
@@ -45,6 +45,12 @@ const additionalTemplate = html`
             @apply --layout-center;
             padding: 16px 16px 16px 0;
             border-bottom: 1px solid #DDD;
+            /* Long-pressing selectable text competes with drag initiation on touch devices. */
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            -webkit-touch-callout: none;
         }
         .item:hover {
             background-color: var(--google-grey-100);

--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
@@ -423,6 +423,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
     }
 
     disconnectedCallback () {
+        this._clearDragState();
         this._dndCancelHoldTimer();
         this._reportDndDiag();
         super.disconnectedCallback();
@@ -953,7 +954,14 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
                 dragEvent.dataTransfer.effectAllowed = "copyMove";
                 dragEvent.dataTransfer.setDragImage(elementToDrag, relMousePos.x, relMousePos.y); 
                 hideTooltip();
-                setTimeout(() => {
+                // Assignment of the dragging state is deferred, because it hides the row through `[is-dragging-item]`
+                // and, on a desktop, the drag handle that carries `draggable` through `drag-mode` on `iron-list`.
+                // Hiding the source of a drag synchronously within `dragstart` aborts the drag on WebKit.
+                // Assigning it synchronously was measured on macOS Safari 26.5 as two drags that started and ended without ever producing a drop.
+                // The same measurement on Chrome 151 for Android completed its drag, so the abort is specific to WebKit rather than common to every engine.
+                // The handle is retained so that the assignment can be cancelled when a drag ends before the timer runs.
+                this._dragStateTimer = setTimeout(() => {
+                    this._dragStateTimer = null;
                     const itemIndex = this._getIndexForElement(elementToDrag);
                     this._reorderingObject = {
                         origin: itemIndex,
@@ -985,8 +993,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
             this._countDnd("dropped");
             const chosenIds = this.entity.get("chosenIds");
             this.entity.setAndRegisterPropertyTouch("chosenIds", this._entities.filter(entity => chosenIds.indexOf(this.idOrKey(entity)) >= 0).map(entity => this.idOrKey(entity)));
-            delete this._reorderingObject;
-            this._draggingItem = null;
+            this._clearDragState();
             // Invoke validation after user has completed item reordering.
             this._invokeValidation.bind(this)();
         }
@@ -996,9 +1003,24 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
         this._countDnd("dragend");
         if (this._reorderingObject) {
             this.moveItem(this._reorderingObject.from, this._reorderingObject.origin);
-            delete this._reorderingObject;
-            this._draggingItem = null;
         }
+        this._clearDragState();
+    }
+
+    /**
+     * Cancels a pending assignment of the dragging state and clears whatever has already been assigned.
+     * This runs on every `dragend`, whether or not a drop occurred, so that nothing outlives a drag.
+     * A drag can end before the deferred assignment in `_startDrag` runs, which is the case on engines that abort a drag promptly.
+     * The state would then be assigned after the drag had ended and would never be cleared, leaving the row hidden by `[is-dragging-item]` indefinitely.
+     * A surviving `_reorderingObject` would also allow a later `dragover` to reorder items outside of a drag, which can leave the displayed order different from the order recorded in `chosenIds`.
+     */
+    _clearDragState () {
+        if (this._dragStateTimer) {
+            clearTimeout(this._dragStateTimer);
+            this._dragStateTimer = null;
+        }
+        delete this._reorderingObject;
+        this._draggingItem = null;
     }
     
     /**

--- a/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
+++ b/platform-web-ui/src/main/web/ua/com/fielden/platform/web/editors/tg-collectional-editor.js
@@ -952,7 +952,7 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
                 this._countDnd("dragInit");
                 const relMousePos = getRelativePos(dragEvent.clientX, dragEvent.clientY, elementToDrag);
                 dragEvent.dataTransfer.effectAllowed = "copyMove";
-                dragEvent.dataTransfer.setDragImage(elementToDrag, relMousePos.x, relMousePos.y); 
+                dragEvent.dataTransfer.setDragImage(this._createDragImage(elementToDrag), relMousePos.x, relMousePos.y);
                 hideTooltip();
                 // Assignment of the dragging state is deferred, because it hides the row through `[is-dragging-item]`
                 // and, on a desktop, the drag handle that carries `draggable` through `drag-mode` on `iron-list`.
@@ -1019,8 +1019,66 @@ export class TgCollectionalEditor extends GestureEventListeners(TgEditor) {
             clearTimeout(this._dragStateTimer);
             this._dragStateTimer = null;
         }
+        this._removeDragImage();
         delete this._reorderingObject;
         this._draggingItem = null;
+    }
+
+    /**
+     * Creates an untransformed copy of the specified row to serve as the drag image.
+     * `iron-list` positions every row with an inline `transform: translate3d(0, Ypx, 0)`, so only the first row of an unscrolled list has `Y` of `0`.
+     * WebKit appears to disregard that transform when it rasterises a drag image, painting the row outside the bounds of the resulting bitmap.
+     * The drag then has no visual representation for every row except the one at `Y` of `0`, as observed on macOS Safari 26.5 for issue #2819.
+     * Clearing `transform` on the copy removes that offset, which is the whole point of taking a copy.
+     * The copy is appended to this shadow root so that the same scoped rules style it as a row, and it is positioned off-screen so that it can be neither seen nor interacted with.
+     */
+    _createDragImage (elementToDrag) {
+        this._removeDragImage();
+        const rect = elementToDrag.getBoundingClientRect();
+        const dragImage = elementToDrag.cloneNode(true);
+        // The copy must not be mistaken for a row by the drag handlers or by the diagnostics.
+        dragImage.removeAttribute("drag-element");
+        dragImage.removeAttribute("collectional-index");
+        dragImage.removeAttribute("draggable");
+        // `cloneNode` copies the `style` attribute, so the inline transform of the row has to be cleared explicitly.
+        dragImage.style.transform = "none";
+        dragImage.style.position = "fixed";
+        dragImage.style.top = "0";
+        dragImage.style.left = "-100000px";
+        dragImage.style.width = `${rect.width}px`;
+        dragImage.style.height = `${rect.height}px`;
+        dragImage.style.pointerEvents = "none";
+        dragImage.style.setProperty("--paper-checkbox-animation-duration", "0s");
+        this.shadowRoot.appendChild(dragImage);
+        this._settleDragImageCheckboxes(dragImage);
+        dragImage.offsetHeight; // forces layout, so that an engine rasterising synchronously within `setDragImage` finds the copy laid out
+        this._dragImage = dragImage;
+        return dragImage;
+    }
+
+    /**
+     * Puts the checkboxes of a drag image straight into their settled state.
+     * `cloneNode` does not copy shadow DOM, so each cloned `paper-checkbox` is upgraded afresh and restarts `checkmark-expand`,
+     * an animation that expands the tick from `scale(0, 0)` over 140ms and supplies the only transform the tick ever has.
+     * A drag image is rasterised long before that completes, which captures a checked box as a plain blue square.
+     * `--paper-checkbox-animation-duration` is the documented way to collapse the animation, and the final transform is
+     * also assigned directly, because a zero duration still leaves the tick relying on the fill being applied in time.
+     */
+    _settleDragImageCheckboxes (dragImage) {
+        dragImage.querySelectorAll("paper-checkbox").forEach(checkbox => {
+            const checkmark = checkbox.shadowRoot && checkbox.shadowRoot.querySelector("#checkmark");
+            if (checkmark) {
+                checkmark.style.animation = "none";
+                checkmark.style.transform = "scale(1, 1) rotate(45deg)";
+            }
+        });
+    }
+
+    _removeDragImage () {
+        if (this._dragImage) {
+            this._dragImage.remove();
+            this._dragImage = null;
+        }
     }
     
     /**


### PR DESCRIPTION
Resolve #2819

# To be completed by the pull request creator

This section should be completed with reference to section [Preparing PR](https://github.com/fieldenms/devops/wiki/Code-and-PR-reviews#preparing-pr) of the [Code and PR reviews](https://github.com/fieldenms/devops/wiki/Code-and-PR-reviews) wiki page.

<!-- Delete any items that are not applicable. -->

- [x] Create the pull request as a draft by tapping the dropdown arrow on the 'Create pull request' button under the pull request description (below the text box where this description is being edited) and changing the default `Create pull request` to `Draft pull request`.
      Or, if the pull request has already been created, convert it to draft by tapping the "Convert to draft" link beneath the "Reviewers" section.

- [x] A self-review of all changes has been completed, and the changes are in sync with the issue requirements.

- [x] Changes to the requirements have been reflected in the issue description.

- [x] Any "leftovers" such as sysouts, printing of stack traces, and any other "temporary" code, have been removed.

- [x] Developer documentation (e.g., comments, Javadoc), have been provided where required.

- [x] The correct base branch has been selected for these changes to be merged into.

- [x] The latest changes from the base branch have already been merged into this feature branch (and tested).

- [x] This pull request does not contain significant changes, and at least one appropriate reviewer has been selected.

- [x] The `In progress` label has been removed from the issue.

- [x] The `Pull request` label has been added to the issue.

- [x] The pull request has been made ready for review by tapping the "Ready for review" button below the list of commits on the pull request page.

# To be completed by the pull request reviewer

This section should be completed with reference to section [Performing PR review](https://github.com/fieldenms/devops/wiki/Code-and-PR-reviews#performing-pr-review) of the [Code and PR reviews](https://github.com/fieldenms/devops/wiki/Code-and-PR-reviews) wiki page.

<!-- Delete any items that are not applicable. -->

- [ ] The `In progress` label has been added to the pull request in GitHub.

- [ ] The issue requirements have been read and understood (along with any relevant emails and/or Slack messages).

- [ ] The correct base branch is specified, and that base branch is up-to-date in the local source.

- [ ] The issue branch has been checked out locally, and had the base branch merged into it.

- [ ] All automated tests pass successfully.

- [ ] Ensure the implementation satisfies the functional requirements.

- [ ] Ensure that code changes are secure and align with the established coding practices, including code formatting and naming conventions.

- [ ] Ensure that code changes are documented and covered with automated tests as applicable.

- [ ] Ensure that code changes are well-suited for informal reasoning.

- [ ] Ensure that changes are documented for the end-user (a software engineer in the case of TG, or an application user in the case of TG-based applications).

- [ ] If there are significant changes (described above), special attention has been paid to them.
      Marked the task items in section "Significant changes" as completed to indicate that corresponding changes have been reviewed, improved if necessary, and approved.

- [ ] The issue or issues addressed by the pull request are associated with the relevant release milestone.

# To be completed by the pull request reviewer once the changes have been reviewed and accepted

- [ ] The changes have been merged into the base branch (unless there is a specific request not to do so, e.g., they are to be released to SIT).

- [ ] The issue branch has been deleted (unless the changes have not been merged - see above, or there is a specific request not to do so).

- [ ] The `In progress` label has been removed from the pull request.

- [ ] The `Pull request` label has been removed from the issue.

